### PR TITLE
Make Arena upload idempotent to prevent infinite re-uploads

### DIFF
--- a/utils/arena.ts
+++ b/utils/arena.ts
@@ -1065,7 +1065,20 @@ export async function createBlock({
     throw new Error("failed to get block id from response");
   }
 
-  const blockInfo = await getBlock(blockId, arenaToken);
+  // getBlock is a best-effort enrichment call (mainly for the image field).
+  // If it fails, we still have the essential data (blockId + connections) from
+  // the GraphQL response. Letting this failure propagate previously caused
+  // the local DB save to be skipped entirely, leaving the block "pending"
+  // and causing infinite re-uploads.
+  let blockInfo: RawArenaBlock;
+  try {
+    blockInfo = await getBlock(blockId, arenaToken);
+  } catch (err) {
+    logError(
+      `[Arena] getBlock enrichment failed for ${blockId}, using minimal data: ${err}`
+    );
+    blockInfo = { id: Number(blockId) } as RawArenaBlock;
+  }
   return {
     arenaBlock: blockInfo,
     connections,

--- a/utils/db.tsx
+++ b/utils/db.tsx
@@ -1973,25 +1973,45 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
           // @ts-ignore
           const connectionsToSync: BlockWithCollectionInfo[] = result.rows
             .map((block) => {
-              const blockMappedToCamelCase =
-                mapSnakeCaseToCamelCaseProperties(block);
-              const mappedBlock = mapDbBlockToBlock(block);
-              return {
-                ...blockMappedToCamelCase,
-                ...mappedBlock,
-                collectionRemoteSourceTypes:
-                  blockMappedToCamelCase.collectionRemoteSourceTypes as RemoteSourceType[],
-                collectionRemoteSourceInfos:
-                  blockMappedToCamelCase.collectionRemoteSourceInfos
-                    ? (JSON.parse(
-                        blockMappedToCamelCase.collectionRemoteSourceInfos
-                      ).map(
-                        (info: string) => JSON.parse(info) as RemoteSourceInfo
-                      ) as RemoteSourceInfo[])
-                    : null,
-              } as BlockWithCollectionInfo;
+              try {
+                const blockMappedToCamelCase =
+                  mapSnakeCaseToCamelCaseProperties(block);
+                const mappedBlock = mapDbBlockToBlock(block);
+
+                let collectionRemoteSourceInfos: RemoteSourceInfo[] | null =
+                  null;
+                if (blockMappedToCamelCase.collectionRemoteSourceInfos) {
+                  const parsed = JSON.parse(
+                    blockMappedToCamelCase.collectionRemoteSourceInfos
+                  );
+                  // json_group_array may return items as JSON objects (not
+                  // double-quoted strings) depending on SQLite version, so
+                  // handle both cases.
+                  collectionRemoteSourceInfos = parsed.map((info: any) =>
+                    typeof info === "string"
+                      ? (JSON.parse(info) as RemoteSourceInfo)
+                      : (info as RemoteSourceInfo)
+                  );
+                }
+
+                return {
+                  ...blockMappedToCamelCase,
+                  ...mappedBlock,
+                  collectionRemoteSourceTypes:
+                    blockMappedToCamelCase.collectionRemoteSourceTypes as RemoteSourceType[],
+                  collectionRemoteSourceInfos,
+                } as BlockWithCollectionInfo;
+              } catch (err) {
+                logError(
+                  `[Arena Sync] Failed to parse pending block row id=${block.id}: ${err}`
+                );
+                return null;
+              }
             })
-            .filter((b) => !queuedBlocksToSync.current.has(b.id));
+            .filter(
+              (b): b is BlockWithCollectionInfo =>
+                b !== null && !queuedBlocksToSync.current.has(b.id)
+            );
 
           connectionsToSync.forEach((c) =>
             queuedBlocksToSync.current.add(c.id)
@@ -2136,20 +2156,25 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
             block.id,
           ],
         },
-        ...collectionInfos.map((collectionInfo) => ({
-          sql: `INSERT INTO connections (block_id, collection_id, created_by, remote_created_at)
-              VALUES (?, ?, ?, ?)
-              ON CONFLICT(block_id, collection_id) DO UPDATE SET remote_created_at = excluded.remote_created_at;`,
-          args: [
-            block.id,
-            collectionInfo.collectionId,
-            getCreatedByForRemote(
-              RemoteSourceType.Arena,
-              connections[collectionInfo.channelId].user.slug
-            ),
-            connections[collectionInfo.channelId].connected_at,
-          ],
-        })),
+        ...collectionInfos.map((collectionInfo) => {
+          const conn = connections[collectionInfo.channelId];
+          return {
+            sql: `INSERT INTO connections (block_id, collection_id, created_by, remote_created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(block_id, collection_id) DO UPDATE SET remote_created_at = excluded.remote_created_at;`,
+            args: [
+              block.id,
+              collectionInfo.collectionId,
+              conn?.user?.slug
+                ? getCreatedByForRemote(
+                    RemoteSourceType.Arena,
+                    conn.user.slug
+                  )
+                : currentUser?.id ?? "unknown",
+              conn?.connected_at ?? new Date().toISOString(),
+            ],
+          };
+        }),
       ];
       const syncResults = await db.execAsync(statements, false);
       handleSqlErrors(syncResults);


### PR DESCRIPTION
Three fixes to prevent the cycle where blocks upload to Arena successfully but fail to record locally, causing endless re-uploads:

1. arena.ts: Make getBlock enrichment call non-fatal. Previously, if the REST call to fetch full block details (mainly for image URLs) failed after the GraphQL create mutation succeeded, the entire operation threw, skipping the local DB save. The block stayed "pending" and re-uploaded on the next sync cycle. Now getBlock failure falls back to minimal data from the GraphQL response.

2. db.tsx syncBlockToArena: Add null safety for connections[channelId] access. If the GraphQL response doesn't include connection data for a channel, we fall back to the current user and current timestamp instead of throwing a TypeError before the DB write.

3. db.tsx trySyncPendingArenaBlocks: Wrap the pending block row mapping in try/catch so one malformed row doesn't kill the entire sync batch. Also handle both string and object forms from json_group_array since SQLite version differences affect whether JSON text values are double-quoted or included as raw JSON.

https://claude.ai/code/session_01RsK9z41n8EHh86m6PLFjVz