### PR TITLE
Custom photo picker with added-photo badges + organize grid view

### DIFF
--- a/app.json
+++ b/app.json
@@ -61,6 +61,14 @@
         }
       ],
       [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow Gather to access your photos so you can browse and add them, and see which ones you've already added.",
+          "savePhotosPermission": "Allow Gather to save photos.",
+          "isAccessMediaLocationEnabled": true
+        }
+      ],
+      [
         "expo-config-plugin-ios-share-extension",
         {
           "activationRules": {

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "buildNumber": "2",
+      "buildNumber": "4",
       "bundleIdentifier": "net.tiny-inter.gather",
       "config": {
         "usesNonExemptEncryption": false

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Gather",
     "slug": "gather",
     "privacy": "unlisted",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "net.tiny-inter.gather",
@@ -16,7 +16,7 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "buildNumber": "22",
+      "buildNumber": "2",
       "bundleIdentifier": "net.tiny-inter.gather",
       "config": {
         "usesNonExemptEncryption": false

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -28,6 +28,7 @@ import {
   useColorScheme,
 } from "react-native";
 import { HoldMenuProvider } from "react-native-hold-menu";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import {
   SafeAreaProvider,
   useSafeAreaInsets,
@@ -98,7 +99,7 @@ export default function RootLayout() {
   useEffect(() => {
     if (Platform.OS === "android") {
       NavigationBar.setBackgroundColorAsync(
-        colorScheme === "light" ? "white" : "black"
+        colorScheme === "light" ? "white" : "black",
       );
     }
   }, [colorScheme]);
@@ -108,43 +109,45 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <SafeAreaProvider>
-        <ErrorsProvider>
-          <TamaguiProvider config={config}>
-            <Theme name={colorScheme === "dark" ? "dark" : "light"}>
-              <QueryClientProvider client={client}>
-                <NetworkProvider>
-                  <HoldMenuProvider
-                    theme={colorScheme || undefined}
-                    safeAreaInsets={insets}
-                    // @ts-ignore
-                    onOpen={() => {
-                      if (Keyboard.isVisible()) {
-                        Keyboard.dismiss();
-                      }
-                    }}
-                  >
-                    <UserProvider>
-                      <DatabaseProvider>
-                        <RootLayoutNav />
-                        <StatusBar
-                          style="auto"
-                          // NOTE: idk why but "auto" doesn't properly change color on Android.
-                          backgroundColor={
-                            colorScheme === "light" ? "white" : "black"
-                          }
-                        />
-                      </DatabaseProvider>
-                    </UserProvider>
-                  </HoldMenuProvider>
-                </NetworkProvider>
-              </QueryClientProvider>
-            </Theme>
-          </TamaguiProvider>
-        </ErrorsProvider>
-      </SafeAreaProvider>
-    </ThemeProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <SafeAreaProvider>
+          <ErrorsProvider>
+            <TamaguiProvider config={config}>
+              <Theme name={colorScheme === "dark" ? "dark" : "light"}>
+                <QueryClientProvider client={client}>
+                  <NetworkProvider>
+                    <HoldMenuProvider
+                      theme={colorScheme || undefined}
+                      safeAreaInsets={insets}
+                      // @ts-ignore
+                      onOpen={() => {
+                        if (Keyboard.isVisible()) {
+                          Keyboard.dismiss();
+                        }
+                      }}
+                    >
+                      <UserProvider>
+                        <DatabaseProvider>
+                          <RootLayoutNav />
+                          <StatusBar
+                            style="auto"
+                            // NOTE: idk why but "auto" doesn't properly change color on Android.
+                            backgroundColor={
+                              colorScheme === "light" ? "white" : "black"
+                            }
+                          />
+                        </DatabaseProvider>
+                      </UserProvider>
+                    </HoldMenuProvider>
+                  </NetworkProvider>
+                </QueryClientProvider>
+              </Theme>
+            </TamaguiProvider>
+          </ErrorsProvider>
+        </SafeAreaProvider>
+      </ThemeProvider>
+    </GestureHandlerRootView>
   );
 }
 

--- a/components/BlockContent.tsx
+++ b/components/BlockContent.tsx
@@ -34,6 +34,7 @@ export function BlockContent({
   textContainerProps = {},
   textProps = {},
   isVisible,
+  zoomable,
 }: Pick<Block, "type" | "content" | "title" | "description"> & {
   isEditing?: boolean;
   commitEdit?: (newContent: string | null) => Promise<void>;
@@ -42,6 +43,7 @@ export function BlockContent({
   textContainerProps?: YStackProps;
   textProps?: ParagraphProps;
   isVisible?: boolean;
+  zoomable?: boolean;
 }) {
   const theme = useTheme();
   let renderedContent;
@@ -105,6 +107,7 @@ export function BlockContent({
           }
           alt={`Image ${title} ${description}`}
           isVisible={isVisible}
+          zoomable={zoomable}
         />
       );
       break;

--- a/components/BlockDetailView.tsx
+++ b/components/BlockDetailView.tsx
@@ -27,7 +27,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 function getDisplayForCreatedBy(
   createdBy: string,
-  arenaUserInfo: RawArenaUser | null
+  arenaUserInfo: RawArenaUser | null,
 ) {
   const { userId, source } = extractCreatorFromCreatedBy(createdBy);
   if (!source) {
@@ -38,7 +38,9 @@ function getDisplayForCreatedBy(
       return (
         <>
           <ExternalLinkText href={`https://are.na/${userId}`}>
-            {arenaUserInfo && userId === arenaUserInfo.slug ? "you" : userId}{" "}
+            {arenaUserInfo && userId === arenaUserInfo.slug
+              ? "you"
+              : userId}{" "}
           </ExternalLinkText>
           <ArenaLogo />
         </>
@@ -76,11 +78,11 @@ export function BlockDetailView({ block }: { block: Block }) {
   const { updateBlock } = useContext(DatabaseContext);
   const { arenaUserInfo } = useContext(UserContext);
   const { data: connections, isLoading: loadingData } = useBlockConnections(
-    id.toString()
+    id.toString(),
   );
   const hasRemoteConnection = useMemo(
     () => connections?.some((c) => Boolean(c.remoteSourceType)),
-    [connections]
+    [connections],
   );
   const createdByDisplay = getDisplayForCreatedBy(createdBy, arenaUserInfo);
   const [devModeEnabled] = useStickyValue("devModeEnabled", false);
@@ -145,13 +147,14 @@ export function BlockDetailView({ block }: { block: Block }) {
                     await updateBlock({
                       blockId: id,
                       editInfo: { title: newTitle },
-                    })
+                    }),
                 );
               }}
             />
             {/* TODO: on delete navigate back */}
             <BlockSummary
               block={block}
+              zoomable
               blockStyle={{
                 objectFit: "contain",
                 aspectRatio: undefined,
@@ -178,7 +181,7 @@ export function BlockDetailView({ block }: { block: Block }) {
                     await updateBlock({
                       blockId: id,
                       editInfo: { description: newDescription },
-                    })
+                    }),
                 );
               }}
             />

--- a/components/BlockSummary.tsx
+++ b/components/BlockSummary.tsx
@@ -42,7 +42,10 @@ const MaxMenuTitleLength = 30;
 
 function useBlockMenuItems(
   block: Block,
-  { onClickEdit, isOwner }: { onClickEdit?: () => void; isOwner?: boolean } = {}
+  {
+    onClickEdit,
+    isOwner,
+  }: { onClickEdit?: () => void; isOwner?: boolean } = {},
 ): {
   blockMenuItems: MenuItemProps[];
 } {
@@ -143,7 +146,7 @@ function useBlockMenuItems(
         },
       },
     ],
-    [id, source, content, type, title, deleteBlock]
+    [id, source, content, type, title, deleteBlock],
   );
 
   return { blockMenuItems };
@@ -159,6 +162,7 @@ export function BlockSummary({
   containerProps,
   editable,
   isVisible,
+  zoomable,
 }: {
   block: Block;
   hideMetadata?: boolean;
@@ -169,6 +173,7 @@ export function BlockSummary({
   containerProps?: GetProps<typeof YStack>;
   editable?: boolean;
   isVisible?: boolean;
+  zoomable?: boolean;
 }) {
   const { id, title, createdAt } = block;
   const { updateBlock } = useContext(DatabaseContext);
@@ -219,9 +224,10 @@ export function BlockSummary({
           ...blockStyle,
         }}
         isVisible={isVisible}
+        zoomable={zoomable}
       />
     ),
-    [block, isEditing, isVisible]
+    [block, isEditing, isVisible, zoomable],
   );
 
   function renderMetadata() {
@@ -244,14 +250,14 @@ export function BlockSummary({
         metadata.push(
           <Fragment key={"link"}>
             from <ExternalLinkText href={source!}>{source}</ExternalLinkText>
-          </Fragment>
+          </Fragment>,
         );
         break;
       case BlockType.Document:
         metadata.push(
           <Fragment key={"link"}>
             from <ExternalLinkText href={content}>{content}</ExternalLinkText>
-          </Fragment>
+          </Fragment>,
         );
         break;
     }
@@ -281,7 +287,7 @@ export function BlockSummary({
                 await updateBlock({
                   blockId: id,
                   editInfo: { title: newTitle },
-                })
+                }),
             );
           }}
         />
@@ -587,7 +593,7 @@ export function BlockReviewSummary({
         isVisible={isVisible}
       />
     ),
-    [block, isVisible, widthProperty, style, blockStyle]
+    [block, isVisible, widthProperty, style, blockStyle],
   );
 
   const dateInfo = useMemo(
@@ -597,7 +603,7 @@ export function BlockReviewSummary({
         dateKind: "absolute",
         includeDescription: true,
       }),
-    [block, isRemoteCollection]
+    [block, isRemoteCollection],
   );
   // TODO: need to truncate title, etc. to make it fit
   const renderedSummary = useMemo(
@@ -639,7 +645,7 @@ export function BlockReviewSummary({
       showBackground,
       blockMenuItems,
       content,
-    ]
+    ],
   );
   return shouldLink ? (
     <Link
@@ -674,7 +680,7 @@ export function BlockMetadata({
   const time = useTime(60 * 1000);
   const dateInfo = useMemo(
     () => getDateForBlock(block, { isRemoteCollection, dateKind }),
-    [time]
+    [time],
   );
 
   let metadata;
@@ -720,14 +726,14 @@ function getDateForBlock(
     isRemoteCollection?: boolean;
     dateKind?: "relative" | "absolute";
     includeDescription?: boolean;
-  }
+  },
 ) {
   const { createdAt, remoteConnectedAt, connectedAt } = block;
 
   const date =
     isRemoteCollection && remoteConnectedAt
       ? remoteConnectedAt
-      : connectedAt ?? createdAt;
+      : (connectedAt ?? createdAt);
   const dateInfo =
     dateKind === "relative"
       ? getRelativeDate(date)
@@ -736,8 +742,8 @@ function getDateForBlock(
     isRemoteCollection && remoteConnectedAt
       ? "synced"
       : connectedAt
-      ? "connected"
-      : "created";
+        ? "connected"
+        : "created";
   return includeDescription ? `${dateDescription} @ ${dateInfo}` : dateInfo;
 }
 
@@ -751,7 +757,7 @@ export function BlockConnections({ block }: { block: Block }) {
       (collectionIds || []).map(async (collectionId) => {
         const collection = await getCollection(collectionId);
         return collection?.title;
-      })
+      }),
     ).then((c) => setCollectionsToShow(c.filter(Boolean)));
   }, []);
 

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -13,13 +13,11 @@ import {
   Image,
   Linking,
   Modal,
+  Platform,
   Pressable,
-} from "react-native";
-import {
-  SafeAreaProvider,
   SafeAreaView,
-  initialWindowMetrics,
-} from "react-native-safe-area-context";
+  StatusBar,
+} from "react-native";
 import { Spinner, XStack, YStack } from "tamagui";
 import { DatabaseContext } from "../utils/db";
 import { ErrorsContext } from "../utils/errors";
@@ -227,11 +225,18 @@ export function CustomPhotoPicker({
       presentationStyle="fullScreen"
       onRequestClose={handleClose}
     >
-      {/* Modals render outside the app's SafeAreaProvider, so re-establish one
-          here — otherwise insets are 0 and the header clips under the notch. */}
-      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-        <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
-          <YStack flex={1} backgroundColor="$background">
+      {/* react-native-safe-area-context insets are 0 inside a Modal, so use
+          RN's native SafeAreaView (reads the real window insets on iOS) and a
+          status-bar fallback on Android to keep the header below the notch. */}
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        paddingTop={
+          Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0
+        }
+      >
+        <SafeAreaView style={{ flex: 1 }}>
+          <YStack flex={1}>
             {/* Header */}
             <XStack
               alignItems="center"
@@ -443,7 +448,7 @@ export function CustomPhotoPicker({
             )}
           </YStack>
         </SafeAreaView>
-      </SafeAreaProvider>
+      </YStack>
     </Modal>
   );
 }

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -1,4 +1,3 @@
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import * as MediaLibrary from "expo-media-library";
 import {
   useCallback,
@@ -16,7 +15,11 @@ import {
   Modal,
   Pressable,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  SafeAreaProvider,
+  SafeAreaView,
+  initialWindowMetrics,
+} from "react-native-safe-area-context";
 import { Spinner, XStack, YStack } from "tamagui";
 import { DatabaseContext } from "../utils/db";
 import { ErrorsContext } from "../utils/errors";
@@ -45,8 +48,6 @@ export function CustomPhotoPicker({
 }: CustomPhotoPickerProps) {
   const { getExistingAssetIds } = useContext(DatabaseContext);
   const { logError } = useContext(ErrorsContext);
-  const insets = useSafeAreaInsets();
-  const bottomTabHeight = useBottomTabBarHeight();
 
   const [permission, requestPermission] = MediaLibrary.usePermissions();
 
@@ -57,7 +58,7 @@ export function CustomPhotoPicker({
 
   // Asset ids that already exist in Gather (queried per page as photos load).
   const [existingAssetIds, setExistingAssetIds] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
   const [filter, setFilter] = useState<FilterMode>("all");
   // Ordered list of selected asset ids (mirrors the native picker's ordered
@@ -66,18 +67,18 @@ export function CustomPhotoPicker({
 
   const sessionAddedSet = useMemo(
     () => new Set(alreadyPickedAssetIds.filter((id): id is string => !!id)),
-    [alreadyPickedAssetIds]
+    [alreadyPickedAssetIds],
   );
 
   const isAdded = useCallback(
     (assetId: string) =>
       existingAssetIds.has(assetId) || sessionAddedSet.has(assetId),
-    [existingAssetIds, sessionAddedSet]
+    [existingAssetIds, sessionAddedSet],
   );
 
   const screenWidth = Dimensions.get("window").width;
   const cellSize = Math.floor(
-    (screenWidth - CellGap * (NumColumns - 1)) / NumColumns
+    (screenWidth - CellGap * (NumColumns - 1)) / NumColumns,
   );
 
   const resetState = useCallback(() => {
@@ -127,7 +128,7 @@ export function CustomPhotoPicker({
 
         // Cross-reference this page against Gather's saved blocks.
         const existing = await getExistingAssetIds(
-          result.assets.map((a) => a.id)
+          result.assets.map((a) => a.id),
         );
         if (existing.length) {
           setExistingAssetIds((prev) => {
@@ -145,7 +146,7 @@ export function CustomPhotoPicker({
         setIsLoading(false);
       }
     },
-    [getExistingAssetIds, logError]
+    [getExistingAssetIds, logError],
   );
 
   // Request permission and load the first page when opened.
@@ -185,10 +186,10 @@ export function CustomPhotoPicker({
       setSelectedIds((prev) =>
         prev.includes(assetId)
           ? prev.filter((id) => id !== assetId)
-          : [...prev, assetId]
+          : [...prev, assetId],
       );
     },
-    [isAdded]
+    [isAdded],
   );
 
   const filteredAssets = useMemo(() => {
@@ -226,214 +227,223 @@ export function CustomPhotoPicker({
       presentationStyle="fullScreen"
       onRequestClose={handleClose}
     >
-      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
-        {/* Header */}
-        <XStack
-          alignItems="center"
-          justifyContent="space-between"
-          paddingHorizontal="$3"
-          paddingVertical="$2.5"
-          gap="$2"
-        >
-          <StyledButton
-            chromeless
-            size="$3"
-            onPress={handleClose}
-            paddingHorizontal="$2"
-            minWidth={72}
-            justifyContent="flex-start"
-          >
-            Cancel
-          </StyledButton>
-          <StyledText bold fontSize="$6">
-            Add photos
-          </StyledText>
-          <StyledButton
-            theme="green"
-            size="$3"
-            disabled={selectedIds.length === 0}
-            opacity={selectedIds.length === 0 ? 0.4 : 1}
-            onPress={handleConfirm}
-            borderRadius={20}
-            minWidth={72}
-          >
-            Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
-          </StyledButton>
-        </XStack>
-
-        {/* Filter segmented control */}
-        <XStack
-          gap="$2"
-          paddingHorizontal="$3"
-          paddingBottom="$2.5"
-          alignItems="center"
-        >
-          {(
-            [
-              ["all", "All"],
-              ["new", "Not added"],
-              ["added", "Added"],
-            ] as [FilterMode, string][]
-          ).map(([mode, label]) => (
-            <Pressable key={mode} onPress={() => setFilter(mode)}>
-              <StyledView
-                paddingHorizontal="$3"
-                paddingVertical="$1.5"
-                borderRadius={16}
-                backgroundColor={filter === mode ? "$orange9" : "$gray4"}
+      {/* Modals render outside the app's SafeAreaProvider, so re-establish one
+          here — otherwise insets are 0 and the header clips under the notch. */}
+      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+        <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
+          <YStack flex={1} backgroundColor="$background">
+            {/* Header */}
+            <XStack
+              alignItems="center"
+              justifyContent="space-between"
+              paddingHorizontal="$3"
+              paddingVertical="$2.5"
+              gap="$2"
+            >
+              <StyledButton
+                chromeless
+                size="$3"
+                onPress={handleClose}
+                paddingHorizontal="$2"
+                minWidth={72}
+                justifyContent="flex-start"
               >
-                <StyledText
-                  fontSize="$3"
-                  color={filter === mode ? "white" : "$color"}
-                >
-                  {label}
-                </StyledText>
-              </StyledView>
-            </Pressable>
-          ))}
-        </XStack>
+                Cancel
+              </StyledButton>
+              <StyledText bold fontSize="$6">
+                Add photos
+              </StyledText>
+              <StyledButton
+                theme="green"
+                size="$3"
+                disabled={selectedIds.length === 0}
+                opacity={selectedIds.length === 0 ? 0.4 : 1}
+                onPress={handleConfirm}
+                borderRadius={20}
+                minWidth={72}
+              >
+                Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
+              </StyledButton>
+            </XStack>
 
-        {permissionDenied ? (
-          <YStack
-            flex={1}
-            alignItems="center"
-            justifyContent="center"
-            gap="$3"
-            paddingHorizontal="$4"
-          >
-            <StyledText textAlign="center">
-              Gather needs access to your photos to add them.
-            </StyledText>
-            <StyledButton theme="orange" onPress={() => Linking.openSettings()}>
-              Open Settings
-            </StyledButton>
-          </YStack>
-        ) : (
-          <FlatList
-            data={filteredAssets}
-            keyExtractor={(item) => item.id}
-            numColumns={NumColumns}
-            onEndReached={handleEndReached}
-            onEndReachedThreshold={1.5}
-            removeClippedSubviews
-            initialNumToRender={PageSize}
-            windowSize={5}
-            contentContainerStyle={{
-              paddingBottom: bottomTabHeight + insets.bottom + 16,
-            }}
-            ListEmptyComponent={
-              isLoading ? null : (
-                <YStack padding="$6" alignItems="center">
-                  <StyledText metadata>
-                    {filter === "added"
-                      ? "Nothing here has been added yet."
-                      : filter === "new"
-                      ? "Everything here is already added."
-                      : "No photos found."}
-                  </StyledText>
-                </YStack>
-              )
-            }
-            ListFooterComponent={
-              isLoading ? (
-                <YStack padding="$4" alignItems="center">
-                  <Spinner size="small" color="$orange9" />
-                </YStack>
-              ) : null
-            }
-            renderItem={({ item }) => {
-              const added = isAdded(item.id);
-              const selectionIndex = selectedIds.indexOf(item.id);
-              const isSelected = selectionIndex !== -1;
-              return (
-                <Pressable
-                  onPress={() => toggleSelect(item.id)}
-                  style={{
-                    width: cellSize,
-                    height: cellSize,
-                    marginRight: CellGap,
-                    marginBottom: CellGap,
-                  }}
-                >
-                  <Image
-                    source={{ uri: item.uri }}
-                    style={{ width: "100%", height: "100%" }}
-                    resizeMode="cover"
-                  />
-
-                  {/* Video duration badge */}
-                  {item.mediaType === MediaLibrary.MediaType.video && (
-                    <XStack
-                      position="absolute"
-                      bottom={4}
-                      right={4}
-                      backgroundColor="rgba(0,0,0,0.6)"
-                      paddingHorizontal={4}
-                      borderRadius={4}
-                      alignItems="center"
-                      gap={2}
+            {/* Filter segmented control */}
+            <XStack
+              gap="$2"
+              paddingHorizontal="$3"
+              paddingBottom="$2.5"
+              alignItems="center"
+            >
+              {(
+                [
+                  ["all", "All"],
+                  ["new", "Not added"],
+                  ["added", "Added"],
+                ] as [FilterMode, string][]
+              ).map(([mode, label]) => (
+                <Pressable key={mode} onPress={() => setFilter(mode)}>
+                  <StyledView
+                    paddingHorizontal="$3"
+                    paddingVertical="$1.5"
+                    borderRadius={16}
+                    backgroundColor={filter === mode ? "$orange9" : "$gray4"}
+                  >
+                    <StyledText
+                      fontSize="$3"
+                      color={filter === mode ? "white" : "$color"}
                     >
-                      <Icon name="videocam" size={10} color="white" />
-                      <StyledText color="white" fontSize={10}>
-                        {formatDuration(item.duration)}
-                      </StyledText>
-                    </XStack>
-                  )}
-
-                  {/* Already-added overlay: dim + checkmark, not selectable */}
-                  {added && (
-                    <StyledView
-                      position="absolute"
-                      top={0}
-                      left={0}
-                      right={0}
-                      bottom={0}
-                      backgroundColor="rgba(0,0,0,0.55)"
-                      alignItems="center"
-                      justifyContent="center"
-                    >
-                      <Icon
-                        name="checkmark-circle"
-                        type={IconType.Ionicons}
-                        size={28}
-                        color="white"
-                      />
-                      <StyledText color="white" fontSize={10} marginTop={2}>
-                        added
-                      </StyledText>
-                    </StyledView>
-                  )}
-
-                  {/* Selection badge */}
-                  {!added && (
-                    <StyledView
-                      position="absolute"
-                      top={6}
-                      right={6}
-                      width={22}
-                      height={22}
-                      borderRadius={11}
-                      borderWidth={1.5}
-                      borderColor="white"
-                      backgroundColor={
-                        isSelected ? "$orange9" : "rgba(0,0,0,0.25)"
-                      }
-                      alignItems="center"
-                      justifyContent="center"
-                    >
-                      {isSelected && (
-                        <StyledText color="white" fontSize={11} bold>
-                          {selectionIndex + 1}
-                        </StyledText>
-                      )}
-                    </StyledView>
-                  )}
+                      {label}
+                    </StyledText>
+                  </StyledView>
                 </Pressable>
-              );
-            }}
-          />
-        )}
-      </YStack>
+              ))}
+            </XStack>
+
+            {permissionDenied ? (
+              <YStack
+                flex={1}
+                alignItems="center"
+                justifyContent="center"
+                gap="$3"
+                paddingHorizontal="$4"
+              >
+                <StyledText textAlign="center">
+                  Gather needs access to your photos to add them.
+                </StyledText>
+                <StyledButton
+                  theme="orange"
+                  onPress={() => Linking.openSettings()}
+                >
+                  Open Settings
+                </StyledButton>
+              </YStack>
+            ) : (
+              <FlatList
+                data={filteredAssets}
+                keyExtractor={(item) => item.id}
+                numColumns={NumColumns}
+                onEndReached={handleEndReached}
+                onEndReachedThreshold={1.5}
+                removeClippedSubviews
+                initialNumToRender={PageSize}
+                windowSize={5}
+                contentContainerStyle={{
+                  paddingBottom: 24,
+                }}
+                ListEmptyComponent={
+                  isLoading ? null : (
+                    <YStack padding="$6" alignItems="center">
+                      <StyledText metadata>
+                        {filter === "added"
+                          ? "Nothing here has been added yet."
+                          : filter === "new"
+                            ? "Everything here is already added."
+                            : "No photos found."}
+                      </StyledText>
+                    </YStack>
+                  )
+                }
+                ListFooterComponent={
+                  isLoading ? (
+                    <YStack padding="$4" alignItems="center">
+                      <Spinner size="small" color="$orange9" />
+                    </YStack>
+                  ) : null
+                }
+                renderItem={({ item }) => {
+                  const added = isAdded(item.id);
+                  const selectionIndex = selectedIds.indexOf(item.id);
+                  const isSelected = selectionIndex !== -1;
+                  return (
+                    <Pressable
+                      onPress={() => toggleSelect(item.id)}
+                      style={{
+                        width: cellSize,
+                        height: cellSize,
+                        marginRight: CellGap,
+                        marginBottom: CellGap,
+                      }}
+                    >
+                      <Image
+                        source={{ uri: item.uri }}
+                        style={{ width: "100%", height: "100%" }}
+                        resizeMode="cover"
+                      />
+
+                      {/* Video duration badge */}
+                      {item.mediaType === MediaLibrary.MediaType.video && (
+                        <XStack
+                          position="absolute"
+                          bottom={4}
+                          right={4}
+                          backgroundColor="rgba(0,0,0,0.6)"
+                          paddingHorizontal={4}
+                          borderRadius={4}
+                          alignItems="center"
+                          gap={2}
+                        >
+                          <Icon name="videocam" size={10} color="white" />
+                          <StyledText color="white" fontSize={10}>
+                            {formatDuration(item.duration)}
+                          </StyledText>
+                        </XStack>
+                      )}
+
+                      {/* Already-added overlay: dim + checkmark, not selectable */}
+                      {added && (
+                        <StyledView
+                          position="absolute"
+                          top={0}
+                          left={0}
+                          right={0}
+                          bottom={0}
+                          backgroundColor="rgba(0,0,0,0.55)"
+                          alignItems="center"
+                          justifyContent="center"
+                        >
+                          <Icon
+                            name="checkmark-circle"
+                            type={IconType.Ionicons}
+                            size={28}
+                            color="white"
+                          />
+                          <StyledText color="white" fontSize={10} marginTop={2}>
+                            added
+                          </StyledText>
+                        </StyledView>
+                      )}
+
+                      {/* Selection badge */}
+                      {!added && (
+                        <StyledView
+                          position="absolute"
+                          top={6}
+                          right={6}
+                          width={22}
+                          height={22}
+                          borderRadius={11}
+                          borderWidth={1.5}
+                          borderColor="white"
+                          backgroundColor={
+                            isSelected ? "$orange9" : "rgba(0,0,0,0.25)"
+                          }
+                          alignItems="center"
+                          justifyContent="center"
+                        >
+                          {isSelected && (
+                            <StyledText color="white" fontSize={11} bold>
+                              {selectionIndex + 1}
+                            </StyledText>
+                          )}
+                        </StyledView>
+                      )}
+                    </Pressable>
+                  );
+                }}
+              />
+            )}
+          </YStack>
+        </SafeAreaView>
+      </SafeAreaProvider>
     </Modal>
   );
 }

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -239,44 +239,12 @@ export function CustomPhotoPicker({
         }
       >
         <YStack flex={1}>
-          {/* Header */}
-          <XStack
-            alignItems="center"
-            justifyContent="space-between"
-            paddingHorizontal="$3"
-            paddingVertical="$2.5"
-            gap="$2"
-          >
-            <StyledButton
-              chromeless
-              size="$3"
-              onPress={handleClose}
-              paddingHorizontal="$2"
-              minWidth={72}
-              justifyContent="flex-start"
-            >
-              Cancel
-            </StyledButton>
-            <StyledText bold fontSize="$6">
-              Add photos
-            </StyledText>
-            <StyledButton
-              theme="green"
-              size="$3"
-              disabled={selectedIds.length === 0}
-              opacity={selectedIds.length === 0 ? 0.4 : 1}
-              onPress={handleConfirm}
-              borderRadius={20}
-              minWidth={72}
-            >
-              Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
-            </StyledButton>
-          </XStack>
-
-          {/* Filter segmented control */}
+          {/* No top bar — swipe the sheet down to dismiss. Filters sit up top
+              with extra padding so they clear the sheet's grab handle. */}
           <XStack
             gap="$2"
             paddingHorizontal="$3"
+            paddingTop="$5"
             paddingBottom="$2.5"
             alignItems="center"
           >
@@ -328,13 +296,14 @@ export function CustomPhotoPicker({
               data={filteredAssets}
               keyExtractor={(item) => item.id}
               numColumns={NumColumns}
+              style={{ flex: 1 }}
               onEndReached={handleEndReached}
               onEndReachedThreshold={1.5}
               removeClippedSubviews
               initialNumToRender={PageSize}
               windowSize={5}
               contentContainerStyle={{
-                paddingBottom: bottomInset + 24,
+                paddingBottom: 24,
               }}
               ListEmptyComponent={
                 isLoading ? null : (
@@ -447,6 +416,33 @@ export function CustomPhotoPicker({
                 );
               }}
             />
+          )}
+
+          {/* Full-width Add button pinned to the bottom */}
+          {!permissionDenied && (
+            <YStack
+              paddingHorizontal="$3"
+              paddingTop="$2.5"
+              paddingBottom={bottomInset + 12}
+              borderTopWidth={1}
+              borderTopColor="$gray4"
+              backgroundColor="$background"
+            >
+              <StyledButton
+                theme="green"
+                size="$5"
+                borderRadius={14}
+                disabled={selectedIds.length === 0}
+                opacity={selectedIds.length === 0 ? 0.5 : 1}
+                onPress={handleConfirm}
+              >
+                {selectedIds.length > 0
+                  ? `Add ${selectedIds.length} photo${
+                      selectedIds.length > 1 ? "s" : ""
+                    }`
+                  : "Select photos to add"}
+              </StyledButton>
+            </YStack>
           )}
         </YStack>
       </YStack>

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -35,9 +35,8 @@ interface CustomPhotoPickerProps {
   // Asset ids already staged in the composer this session. Treated the same as
   // assets already saved to Gather: shown as "added" and not selectable.
   alreadyPickedAssetIds?: (string | null | undefined)[];
-  // Safe-area insets captured by the parent. Passed in because
-  // useSafeAreaInsets() reports 0 inside a native Modal.
-  topInset?: number;
+  // Bottom safe-area inset captured by the parent (useSafeAreaInsets() reports
+  // 0 inside a native Modal) so the grid clears the home indicator.
   bottomInset?: number;
 }
 
@@ -46,7 +45,6 @@ export function CustomPhotoPicker({
   onClose,
   onConfirm,
   alreadyPickedAssetIds = [],
-  topInset = 0,
   bottomInset = 0,
 }: CustomPhotoPickerProps) {
   const { getExistingAssetIds } = useContext(DatabaseContext);
@@ -227,19 +225,18 @@ export function CustomPhotoPicker({
     <Modal
       visible={visible}
       animationType="slide"
-      presentationStyle="fullScreen"
+      // pageSheet presents the picker as a card the OS already insets below the
+      // notch/Dynamic Island, so there's nothing for the header to clip under.
+      // On Android presentationStyle is ignored, so pad for the status bar.
+      presentationStyle="pageSheet"
       onRequestClose={handleClose}
     >
-      {/* useSafeAreaInsets() reports 0 inside a Modal, so the parent passes its
-          captured insets in — the fullScreen Modal covers the whole window so
-          the window insets apply directly. Add a small status-bar fallback. */}
       <YStack
         flex={1}
         backgroundColor="$background"
-        paddingTop={Math.max(
-          topInset,
-          Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0,
-        )}
+        paddingTop={
+          Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0
+        }
       >
         <YStack flex={1}>
           {/* Header */}

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -431,7 +431,10 @@ export function CustomPhotoPicker({
               <StyledButton
                 theme="green"
                 size="$5"
-                borderRadius={14}
+                height={68}
+                borderRadius={16}
+                fontSize="$6"
+                fontWeight="700"
                 disabled={selectedIds.length === 0}
                 opacity={selectedIds.length === 0 ? 0.5 : 1}
                 onPress={handleConfirm}

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -431,9 +431,9 @@ export function CustomPhotoPicker({
               <StyledButton
                 theme="green"
                 size="$5"
-                height={68}
-                borderRadius={16}
-                fontSize="$6"
+                height={54}
+                borderRadius={14}
+                fontSize="$5"
                 fontWeight="700"
                 disabled={selectedIds.length === 0}
                 opacity={selectedIds.length === 0 ? 0.5 : 1}

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -13,12 +13,13 @@ import {
   FlatList,
   Image,
   Linking,
-  Platform,
+  Modal,
   Pressable,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Spinner, XStack, YStack } from "tamagui";
 import { DatabaseContext } from "../utils/db";
+import { ErrorsContext } from "../utils/errors";
 import { Icon, IconType, StyledButton, StyledText, StyledView } from "./Themed";
 
 const PageSize = 90;
@@ -43,6 +44,7 @@ export function CustomPhotoPicker({
   alreadyPickedAssetIds = [],
 }: CustomPhotoPickerProps) {
   const { getExistingAssetIds } = useContext(DatabaseContext);
+  const { logError } = useContext(ErrorsContext);
   const insets = useSafeAreaInsets();
   const bottomTabHeight = useBottomTabBarHeight();
 
@@ -68,7 +70,8 @@ export function CustomPhotoPicker({
   );
 
   const isAdded = useCallback(
-    (assetId: string) => existingAssetIds.has(assetId) || sessionAddedSet.has(assetId),
+    (assetId: string) =>
+      existingAssetIds.has(assetId) || sessionAddedSet.has(assetId),
     [existingAssetIds, sessionAddedSet]
   );
 
@@ -86,13 +89,18 @@ export function CustomPhotoPicker({
     setFilter("all");
   }, []);
 
-  // Track the latest cursor synchronously so rapid onEndReached calls don't
-  // re-request the same page.
+  // Track loading synchronously so rapid onEndReached calls don't double-fetch.
   const loadingRef = useRef(false);
 
   const loadPage = useCallback(
     async (cursor: string | undefined) => {
       if (loadingRef.current) {
+        return;
+      }
+      // Never touch the media library before we actually have permission —
+      // otherwise getAssetsAsync throws "MEDIA_LIBRARY permission is required".
+      const perm = await MediaLibrary.getPermissionsAsync();
+      if (!perm.granted) {
         return;
       }
       loadingRef.current = true;
@@ -128,12 +136,16 @@ export function CustomPhotoPicker({
             return next;
           });
         }
+      } catch (err) {
+        // Swallow so we never surface an unhandled rejection; stop paging.
+        logError(err);
+        setHasNextPage(false);
       } finally {
         loadingRef.current = false;
         setIsLoading(false);
       }
     },
-    [getExistingAssetIds]
+    [getExistingAssetIds, logError]
   );
 
   // Request permission and load the first page when opened.
@@ -141,16 +153,20 @@ export function CustomPhotoPicker({
     if (!visible) {
       return;
     }
+    let cancelled = false;
     (async () => {
       let granted = permission?.granted;
       if (!granted) {
         const resp = await requestPermission();
         granted = resp.granted;
       }
-      if (granted && assets.length === 0) {
+      if (!cancelled && granted && assets.length === 0) {
         void loadPage(undefined);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, permission?.granted]);
 
@@ -200,49 +216,46 @@ export function CustomPhotoPicker({
     onClose();
   }, [resetState, onClose]);
 
-  if (!visible) {
-    return null;
-  }
-
   const permissionDenied =
     permission && !permission.granted && !permission.canAskAgain;
 
   return (
-    <StyledView
-      position="absolute"
-      top={0}
-      left={0}
-      right={0}
-      bottom={0}
-      backgroundColor="$background"
-      zIndex={1000}
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      onRequestClose={handleClose}
     >
-      <YStack flex={1} paddingTop={insets.top}>
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
         {/* Header */}
         <XStack
           alignItems="center"
           justifyContent="space-between"
           paddingHorizontal="$3"
-          paddingVertical="$2"
+          paddingVertical="$2.5"
+          gap="$2"
         >
           <StyledButton
             chromeless
-            circular
             size="$3"
-            icon={<Icon name="close" size={24} />}
             onPress={handleClose}
-            paddingHorizontal={0}
-          />
-          <StyledText bold fontSize="$5">
+            paddingHorizontal="$2"
+            minWidth={72}
+            justifyContent="flex-start"
+          >
+            Cancel
+          </StyledButton>
+          <StyledText bold fontSize="$6">
             Add photos
           </StyledText>
           <StyledButton
             theme="green"
             size="$3"
             disabled={selectedIds.length === 0}
-            opacity={selectedIds.length === 0 ? 0.5 : 1}
+            opacity={selectedIds.length === 0 ? 0.4 : 1}
             onPress={handleConfirm}
             borderRadius={20}
+            minWidth={72}
           >
             Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
           </StyledButton>
@@ -252,7 +265,7 @@ export function CustomPhotoPicker({
         <XStack
           gap="$2"
           paddingHorizontal="$3"
-          paddingBottom="$2"
+          paddingBottom="$2.5"
           alignItems="center"
         >
           {(
@@ -262,17 +275,21 @@ export function CustomPhotoPicker({
               ["added", "Added"],
             ] as [FilterMode, string][]
           ).map(([mode, label]) => (
-            <StyledButton
-              key={mode}
-              size="$2"
-              chromeless={filter !== mode}
-              theme={filter === mode ? "orange" : undefined}
-              backgroundColor={filter === mode ? "$orange4" : "$gray3"}
-              borderRadius={16}
-              onPress={() => setFilter(mode)}
-            >
-              <StyledText fontSize="$2">{label}</StyledText>
-            </StyledButton>
+            <Pressable key={mode} onPress={() => setFilter(mode)}>
+              <StyledView
+                paddingHorizontal="$3"
+                paddingVertical="$1.5"
+                borderRadius={16}
+                backgroundColor={filter === mode ? "$orange9" : "$gray4"}
+              >
+                <StyledText
+                  fontSize="$3"
+                  color={filter === mode ? "white" : "$color"}
+                >
+                  {label}
+                </StyledText>
+              </StyledView>
+            </Pressable>
           ))}
         </XStack>
 
@@ -398,7 +415,9 @@ export function CustomPhotoPicker({
                       borderRadius={11}
                       borderWidth={1.5}
                       borderColor="white"
-                      backgroundColor={isSelected ? "$orange9" : "rgba(0,0,0,0.25)"}
+                      backgroundColor={
+                        isSelected ? "$orange9" : "rgba(0,0,0,0.25)"
+                      }
                       alignItems="center"
                       justifyContent="center"
                     >
@@ -415,7 +434,7 @@ export function CustomPhotoPicker({
           />
         )}
       </YStack>
-    </StyledView>
+    </Modal>
   );
 }
 

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -15,7 +15,6 @@ import {
   Modal,
   Platform,
   Pressable,
-  SafeAreaView,
   StatusBar,
 } from "react-native";
 import { Spinner, XStack, YStack } from "tamagui";
@@ -36,6 +35,10 @@ interface CustomPhotoPickerProps {
   // Asset ids already staged in the composer this session. Treated the same as
   // assets already saved to Gather: shown as "added" and not selectable.
   alreadyPickedAssetIds?: (string | null | undefined)[];
+  // Safe-area insets captured by the parent. Passed in because
+  // useSafeAreaInsets() reports 0 inside a native Modal.
+  topInset?: number;
+  bottomInset?: number;
 }
 
 export function CustomPhotoPicker({
@@ -43,6 +46,8 @@ export function CustomPhotoPicker({
   onClose,
   onConfirm,
   alreadyPickedAssetIds = [],
+  topInset = 0,
+  bottomInset = 0,
 }: CustomPhotoPickerProps) {
   const { getExistingAssetIds } = useContext(DatabaseContext);
   const { logError } = useContext(ErrorsContext);
@@ -225,229 +230,228 @@ export function CustomPhotoPicker({
       presentationStyle="fullScreen"
       onRequestClose={handleClose}
     >
-      {/* react-native-safe-area-context insets are 0 inside a Modal, so use
-          RN's native SafeAreaView (reads the real window insets on iOS) and a
-          status-bar fallback on Android to keep the header below the notch. */}
+      {/* useSafeAreaInsets() reports 0 inside a Modal, so the parent passes its
+          captured insets in — the fullScreen Modal covers the whole window so
+          the window insets apply directly. Add a small status-bar fallback. */}
       <YStack
         flex={1}
         backgroundColor="$background"
-        paddingTop={
-          Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0
-        }
+        paddingTop={Math.max(
+          topInset,
+          Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0,
+        )}
       >
-        <SafeAreaView style={{ flex: 1 }}>
-          <YStack flex={1}>
-            {/* Header */}
-            <XStack
-              alignItems="center"
-              justifyContent="space-between"
-              paddingHorizontal="$3"
-              paddingVertical="$2.5"
-              gap="$2"
+        <YStack flex={1}>
+          {/* Header */}
+          <XStack
+            alignItems="center"
+            justifyContent="space-between"
+            paddingHorizontal="$3"
+            paddingVertical="$2.5"
+            gap="$2"
+          >
+            <StyledButton
+              chromeless
+              size="$3"
+              onPress={handleClose}
+              paddingHorizontal="$2"
+              minWidth={72}
+              justifyContent="flex-start"
             >
-              <StyledButton
-                chromeless
-                size="$3"
-                onPress={handleClose}
-                paddingHorizontal="$2"
-                minWidth={72}
-                justifyContent="flex-start"
-              >
-                Cancel
-              </StyledButton>
-              <StyledText bold fontSize="$6">
-                Add photos
+              Cancel
+            </StyledButton>
+            <StyledText bold fontSize="$6">
+              Add photos
+            </StyledText>
+            <StyledButton
+              theme="green"
+              size="$3"
+              disabled={selectedIds.length === 0}
+              opacity={selectedIds.length === 0 ? 0.4 : 1}
+              onPress={handleConfirm}
+              borderRadius={20}
+              minWidth={72}
+            >
+              Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
+            </StyledButton>
+          </XStack>
+
+          {/* Filter segmented control */}
+          <XStack
+            gap="$2"
+            paddingHorizontal="$3"
+            paddingBottom="$2.5"
+            alignItems="center"
+          >
+            {(
+              [
+                ["all", "All"],
+                ["new", "Not added"],
+                ["added", "Added"],
+              ] as [FilterMode, string][]
+            ).map(([mode, label]) => (
+              <Pressable key={mode} onPress={() => setFilter(mode)}>
+                <StyledView
+                  paddingHorizontal="$3"
+                  paddingVertical="$1.5"
+                  borderRadius={16}
+                  backgroundColor={filter === mode ? "$orange9" : "$gray4"}
+                >
+                  <StyledText
+                    fontSize="$3"
+                    color={filter === mode ? "white" : "$color"}
+                  >
+                    {label}
+                  </StyledText>
+                </StyledView>
+              </Pressable>
+            ))}
+          </XStack>
+
+          {permissionDenied ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              gap="$3"
+              paddingHorizontal="$4"
+            >
+              <StyledText textAlign="center">
+                Gather needs access to your photos to add them.
               </StyledText>
               <StyledButton
-                theme="green"
-                size="$3"
-                disabled={selectedIds.length === 0}
-                opacity={selectedIds.length === 0 ? 0.4 : 1}
-                onPress={handleConfirm}
-                borderRadius={20}
-                minWidth={72}
+                theme="orange"
+                onPress={() => Linking.openSettings()}
               >
-                Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
+                Open Settings
               </StyledButton>
-            </XStack>
-
-            {/* Filter segmented control */}
-            <XStack
-              gap="$2"
-              paddingHorizontal="$3"
-              paddingBottom="$2.5"
-              alignItems="center"
-            >
-              {(
-                [
-                  ["all", "All"],
-                  ["new", "Not added"],
-                  ["added", "Added"],
-                ] as [FilterMode, string][]
-              ).map(([mode, label]) => (
-                <Pressable key={mode} onPress={() => setFilter(mode)}>
-                  <StyledView
-                    paddingHorizontal="$3"
-                    paddingVertical="$1.5"
-                    borderRadius={16}
-                    backgroundColor={filter === mode ? "$orange9" : "$gray4"}
-                  >
-                    <StyledText
-                      fontSize="$3"
-                      color={filter === mode ? "white" : "$color"}
-                    >
-                      {label}
+            </YStack>
+          ) : (
+            <FlatList
+              data={filteredAssets}
+              keyExtractor={(item) => item.id}
+              numColumns={NumColumns}
+              onEndReached={handleEndReached}
+              onEndReachedThreshold={1.5}
+              removeClippedSubviews
+              initialNumToRender={PageSize}
+              windowSize={5}
+              contentContainerStyle={{
+                paddingBottom: bottomInset + 24,
+              }}
+              ListEmptyComponent={
+                isLoading ? null : (
+                  <YStack padding="$6" alignItems="center">
+                    <StyledText metadata>
+                      {filter === "added"
+                        ? "Nothing here has been added yet."
+                        : filter === "new"
+                          ? "Everything here is already added."
+                          : "No photos found."}
                     </StyledText>
-                  </StyledView>
-                </Pressable>
-              ))}
-            </XStack>
+                  </YStack>
+                )
+              }
+              ListFooterComponent={
+                isLoading ? (
+                  <YStack padding="$4" alignItems="center">
+                    <Spinner size="small" color="$orange9" />
+                  </YStack>
+                ) : null
+              }
+              renderItem={({ item }) => {
+                const added = isAdded(item.id);
+                const selectionIndex = selectedIds.indexOf(item.id);
+                const isSelected = selectionIndex !== -1;
+                return (
+                  <Pressable
+                    onPress={() => toggleSelect(item.id)}
+                    style={{
+                      width: cellSize,
+                      height: cellSize,
+                      marginRight: CellGap,
+                      marginBottom: CellGap,
+                    }}
+                  >
+                    <Image
+                      source={{ uri: item.uri }}
+                      style={{ width: "100%", height: "100%" }}
+                      resizeMode="cover"
+                    />
 
-            {permissionDenied ? (
-              <YStack
-                flex={1}
-                alignItems="center"
-                justifyContent="center"
-                gap="$3"
-                paddingHorizontal="$4"
-              >
-                <StyledText textAlign="center">
-                  Gather needs access to your photos to add them.
-                </StyledText>
-                <StyledButton
-                  theme="orange"
-                  onPress={() => Linking.openSettings()}
-                >
-                  Open Settings
-                </StyledButton>
-              </YStack>
-            ) : (
-              <FlatList
-                data={filteredAssets}
-                keyExtractor={(item) => item.id}
-                numColumns={NumColumns}
-                onEndReached={handleEndReached}
-                onEndReachedThreshold={1.5}
-                removeClippedSubviews
-                initialNumToRender={PageSize}
-                windowSize={5}
-                contentContainerStyle={{
-                  paddingBottom: 24,
-                }}
-                ListEmptyComponent={
-                  isLoading ? null : (
-                    <YStack padding="$6" alignItems="center">
-                      <StyledText metadata>
-                        {filter === "added"
-                          ? "Nothing here has been added yet."
-                          : filter === "new"
-                            ? "Everything here is already added."
-                            : "No photos found."}
-                      </StyledText>
-                    </YStack>
-                  )
-                }
-                ListFooterComponent={
-                  isLoading ? (
-                    <YStack padding="$4" alignItems="center">
-                      <Spinner size="small" color="$orange9" />
-                    </YStack>
-                  ) : null
-                }
-                renderItem={({ item }) => {
-                  const added = isAdded(item.id);
-                  const selectionIndex = selectedIds.indexOf(item.id);
-                  const isSelected = selectionIndex !== -1;
-                  return (
-                    <Pressable
-                      onPress={() => toggleSelect(item.id)}
-                      style={{
-                        width: cellSize,
-                        height: cellSize,
-                        marginRight: CellGap,
-                        marginBottom: CellGap,
-                      }}
-                    >
-                      <Image
-                        source={{ uri: item.uri }}
-                        style={{ width: "100%", height: "100%" }}
-                        resizeMode="cover"
-                      />
+                    {/* Video duration badge */}
+                    {item.mediaType === MediaLibrary.MediaType.video && (
+                      <XStack
+                        position="absolute"
+                        bottom={4}
+                        right={4}
+                        backgroundColor="rgba(0,0,0,0.6)"
+                        paddingHorizontal={4}
+                        borderRadius={4}
+                        alignItems="center"
+                        gap={2}
+                      >
+                        <Icon name="videocam" size={10} color="white" />
+                        <StyledText color="white" fontSize={10}>
+                          {formatDuration(item.duration)}
+                        </StyledText>
+                      </XStack>
+                    )}
 
-                      {/* Video duration badge */}
-                      {item.mediaType === MediaLibrary.MediaType.video && (
-                        <XStack
-                          position="absolute"
-                          bottom={4}
-                          right={4}
-                          backgroundColor="rgba(0,0,0,0.6)"
-                          paddingHorizontal={4}
-                          borderRadius={4}
-                          alignItems="center"
-                          gap={2}
-                        >
-                          <Icon name="videocam" size={10} color="white" />
-                          <StyledText color="white" fontSize={10}>
-                            {formatDuration(item.duration)}
+                    {/* Already-added overlay: dim + checkmark, not selectable */}
+                    {added && (
+                      <StyledView
+                        position="absolute"
+                        top={0}
+                        left={0}
+                        right={0}
+                        bottom={0}
+                        backgroundColor="rgba(0,0,0,0.55)"
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        <Icon
+                          name="checkmark-circle"
+                          type={IconType.Ionicons}
+                          size={28}
+                          color="white"
+                        />
+                        <StyledText color="white" fontSize={10} marginTop={2}>
+                          added
+                        </StyledText>
+                      </StyledView>
+                    )}
+
+                    {/* Selection badge */}
+                    {!added && (
+                      <StyledView
+                        position="absolute"
+                        top={6}
+                        right={6}
+                        width={22}
+                        height={22}
+                        borderRadius={11}
+                        borderWidth={1.5}
+                        borderColor="white"
+                        backgroundColor={
+                          isSelected ? "$orange9" : "rgba(0,0,0,0.25)"
+                        }
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        {isSelected && (
+                          <StyledText color="white" fontSize={11} bold>
+                            {selectionIndex + 1}
                           </StyledText>
-                        </XStack>
-                      )}
-
-                      {/* Already-added overlay: dim + checkmark, not selectable */}
-                      {added && (
-                        <StyledView
-                          position="absolute"
-                          top={0}
-                          left={0}
-                          right={0}
-                          bottom={0}
-                          backgroundColor="rgba(0,0,0,0.55)"
-                          alignItems="center"
-                          justifyContent="center"
-                        >
-                          <Icon
-                            name="checkmark-circle"
-                            type={IconType.Ionicons}
-                            size={28}
-                            color="white"
-                          />
-                          <StyledText color="white" fontSize={10} marginTop={2}>
-                            added
-                          </StyledText>
-                        </StyledView>
-                      )}
-
-                      {/* Selection badge */}
-                      {!added && (
-                        <StyledView
-                          position="absolute"
-                          top={6}
-                          right={6}
-                          width={22}
-                          height={22}
-                          borderRadius={11}
-                          borderWidth={1.5}
-                          borderColor="white"
-                          backgroundColor={
-                            isSelected ? "$orange9" : "rgba(0,0,0,0.25)"
-                          }
-                          alignItems="center"
-                          justifyContent="center"
-                        >
-                          {isSelected && (
-                            <StyledText color="white" fontSize={11} bold>
-                              {selectionIndex + 1}
-                            </StyledText>
-                          )}
-                        </StyledView>
-                      )}
-                    </Pressable>
-                  );
-                }}
-              />
-            )}
-          </YStack>
-        </SafeAreaView>
+                        )}
+                      </StyledView>
+                    )}
+                  </Pressable>
+                );
+              }}
+            />
+          )}
+        </YStack>
       </YStack>
     </Modal>
   );

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -1,0 +1,429 @@
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
+import * as MediaLibrary from "expo-media-library";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Dimensions,
+  FlatList,
+  Image,
+  Linking,
+  Platform,
+  Pressable,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Spinner, XStack, YStack } from "tamagui";
+import { DatabaseContext } from "../utils/db";
+import { Icon, IconType, StyledButton, StyledText, StyledView } from "./Themed";
+
+const PageSize = 90;
+const NumColumns = 3;
+const CellGap = 2;
+
+type FilterMode = "all" | "new" | "added";
+
+interface CustomPhotoPickerProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: (assets: MediaLibrary.Asset[]) => void;
+  // Asset ids already staged in the composer this session. Treated the same as
+  // assets already saved to Gather: shown as "added" and not selectable.
+  alreadyPickedAssetIds?: (string | null | undefined)[];
+}
+
+export function CustomPhotoPicker({
+  visible,
+  onClose,
+  onConfirm,
+  alreadyPickedAssetIds = [],
+}: CustomPhotoPickerProps) {
+  const { getExistingAssetIds } = useContext(DatabaseContext);
+  const insets = useSafeAreaInsets();
+  const bottomTabHeight = useBottomTabBarHeight();
+
+  const [permission, requestPermission] = MediaLibrary.usePermissions();
+
+  const [assets, setAssets] = useState<MediaLibrary.Asset[]>([]);
+  const [endCursor, setEndCursor] = useState<string | undefined>(undefined);
+  const [hasNextPage, setHasNextPage] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Asset ids that already exist in Gather (queried per page as photos load).
+  const [existingAssetIds, setExistingAssetIds] = useState<Set<string>>(
+    new Set()
+  );
+  const [filter, setFilter] = useState<FilterMode>("all");
+  // Ordered list of selected asset ids (mirrors the native picker's ordered
+  // selection so the badge numbers match insertion order).
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const sessionAddedSet = useMemo(
+    () => new Set(alreadyPickedAssetIds.filter((id): id is string => !!id)),
+    [alreadyPickedAssetIds]
+  );
+
+  const isAdded = useCallback(
+    (assetId: string) => existingAssetIds.has(assetId) || sessionAddedSet.has(assetId),
+    [existingAssetIds, sessionAddedSet]
+  );
+
+  const screenWidth = Dimensions.get("window").width;
+  const cellSize = Math.floor(
+    (screenWidth - CellGap * (NumColumns - 1)) / NumColumns
+  );
+
+  const resetState = useCallback(() => {
+    setAssets([]);
+    setEndCursor(undefined);
+    setHasNextPage(true);
+    setExistingAssetIds(new Set());
+    setSelectedIds([]);
+    setFilter("all");
+  }, []);
+
+  // Track the latest cursor synchronously so rapid onEndReached calls don't
+  // re-request the same page.
+  const loadingRef = useRef(false);
+
+  const loadPage = useCallback(
+    async (cursor: string | undefined) => {
+      if (loadingRef.current) {
+        return;
+      }
+      loadingRef.current = true;
+      setIsLoading(true);
+      try {
+        const result = await MediaLibrary.getAssetsAsync({
+          first: PageSize,
+          after: cursor,
+          mediaType: [
+            MediaLibrary.MediaType.photo,
+            MediaLibrary.MediaType.video,
+          ],
+          sortBy: [MediaLibrary.SortBy.creationTime],
+        });
+
+        setAssets((prev) => {
+          // De-dupe in case of overlapping pages.
+          const seen = new Set(prev.map((a) => a.id));
+          const next = result.assets.filter((a) => !seen.has(a.id));
+          return [...prev, ...next];
+        });
+        setEndCursor(result.endCursor);
+        setHasNextPage(result.hasNextPage);
+
+        // Cross-reference this page against Gather's saved blocks.
+        const existing = await getExistingAssetIds(
+          result.assets.map((a) => a.id)
+        );
+        if (existing.length) {
+          setExistingAssetIds((prev) => {
+            const next = new Set(prev);
+            existing.forEach((id) => next.add(id));
+            return next;
+          });
+        }
+      } finally {
+        loadingRef.current = false;
+        setIsLoading(false);
+      }
+    },
+    [getExistingAssetIds]
+  );
+
+  // Request permission and load the first page when opened.
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    (async () => {
+      let granted = permission?.granted;
+      if (!granted) {
+        const resp = await requestPermission();
+        granted = resp.granted;
+      }
+      if (granted && assets.length === 0) {
+        void loadPage(undefined);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, permission?.granted]);
+
+  const handleEndReached = useCallback(() => {
+    if (!hasNextPage || loadingRef.current) {
+      return;
+    }
+    void loadPage(endCursor);
+  }, [hasNextPage, endCursor, loadPage]);
+
+  const toggleSelect = useCallback(
+    (assetId: string) => {
+      if (isAdded(assetId)) {
+        return;
+      }
+      setSelectedIds((prev) =>
+        prev.includes(assetId)
+          ? prev.filter((id) => id !== assetId)
+          : [...prev, assetId]
+      );
+    },
+    [isAdded]
+  );
+
+  const filteredAssets = useMemo(() => {
+    switch (filter) {
+      case "new":
+        return assets.filter((a) => !isAdded(a.id));
+      case "added":
+        return assets.filter((a) => isAdded(a.id));
+      default:
+        return assets;
+    }
+  }, [assets, filter, isAdded]);
+
+  const handleConfirm = useCallback(() => {
+    const byId = new Map(assets.map((a) => [a.id, a]));
+    const picked = selectedIds
+      .map((id) => byId.get(id))
+      .filter((a): a is MediaLibrary.Asset => !!a);
+    onConfirm(picked);
+    resetState();
+  }, [assets, selectedIds, onConfirm, resetState]);
+
+  const handleClose = useCallback(() => {
+    resetState();
+    onClose();
+  }, [resetState, onClose]);
+
+  if (!visible) {
+    return null;
+  }
+
+  const permissionDenied =
+    permission && !permission.granted && !permission.canAskAgain;
+
+  return (
+    <StyledView
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      backgroundColor="$background"
+      zIndex={1000}
+    >
+      <YStack flex={1} paddingTop={insets.top}>
+        {/* Header */}
+        <XStack
+          alignItems="center"
+          justifyContent="space-between"
+          paddingHorizontal="$3"
+          paddingVertical="$2"
+        >
+          <StyledButton
+            chromeless
+            circular
+            size="$3"
+            icon={<Icon name="close" size={24} />}
+            onPress={handleClose}
+            paddingHorizontal={0}
+          />
+          <StyledText bold fontSize="$5">
+            Add photos
+          </StyledText>
+          <StyledButton
+            theme="green"
+            size="$3"
+            disabled={selectedIds.length === 0}
+            opacity={selectedIds.length === 0 ? 0.5 : 1}
+            onPress={handleConfirm}
+            borderRadius={20}
+          >
+            Add{selectedIds.length > 0 ? ` (${selectedIds.length})` : ""}
+          </StyledButton>
+        </XStack>
+
+        {/* Filter segmented control */}
+        <XStack
+          gap="$2"
+          paddingHorizontal="$3"
+          paddingBottom="$2"
+          alignItems="center"
+        >
+          {(
+            [
+              ["all", "All"],
+              ["new", "Not added"],
+              ["added", "Added"],
+            ] as [FilterMode, string][]
+          ).map(([mode, label]) => (
+            <StyledButton
+              key={mode}
+              size="$2"
+              chromeless={filter !== mode}
+              theme={filter === mode ? "orange" : undefined}
+              backgroundColor={filter === mode ? "$orange4" : "$gray3"}
+              borderRadius={16}
+              onPress={() => setFilter(mode)}
+            >
+              <StyledText fontSize="$2">{label}</StyledText>
+            </StyledButton>
+          ))}
+        </XStack>
+
+        {permissionDenied ? (
+          <YStack
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+            gap="$3"
+            paddingHorizontal="$4"
+          >
+            <StyledText textAlign="center">
+              Gather needs access to your photos to add them.
+            </StyledText>
+            <StyledButton theme="orange" onPress={() => Linking.openSettings()}>
+              Open Settings
+            </StyledButton>
+          </YStack>
+        ) : (
+          <FlatList
+            data={filteredAssets}
+            keyExtractor={(item) => item.id}
+            numColumns={NumColumns}
+            onEndReached={handleEndReached}
+            onEndReachedThreshold={1.5}
+            removeClippedSubviews
+            initialNumToRender={PageSize}
+            windowSize={5}
+            contentContainerStyle={{
+              paddingBottom: bottomTabHeight + insets.bottom + 16,
+            }}
+            ListEmptyComponent={
+              isLoading ? null : (
+                <YStack padding="$6" alignItems="center">
+                  <StyledText metadata>
+                    {filter === "added"
+                      ? "Nothing here has been added yet."
+                      : filter === "new"
+                      ? "Everything here is already added."
+                      : "No photos found."}
+                  </StyledText>
+                </YStack>
+              )
+            }
+            ListFooterComponent={
+              isLoading ? (
+                <YStack padding="$4" alignItems="center">
+                  <Spinner size="small" color="$orange9" />
+                </YStack>
+              ) : null
+            }
+            renderItem={({ item }) => {
+              const added = isAdded(item.id);
+              const selectionIndex = selectedIds.indexOf(item.id);
+              const isSelected = selectionIndex !== -1;
+              return (
+                <Pressable
+                  onPress={() => toggleSelect(item.id)}
+                  style={{
+                    width: cellSize,
+                    height: cellSize,
+                    marginRight: CellGap,
+                    marginBottom: CellGap,
+                  }}
+                >
+                  <Image
+                    source={{ uri: item.uri }}
+                    style={{ width: "100%", height: "100%" }}
+                    resizeMode="cover"
+                  />
+
+                  {/* Video duration badge */}
+                  {item.mediaType === MediaLibrary.MediaType.video && (
+                    <XStack
+                      position="absolute"
+                      bottom={4}
+                      right={4}
+                      backgroundColor="rgba(0,0,0,0.6)"
+                      paddingHorizontal={4}
+                      borderRadius={4}
+                      alignItems="center"
+                      gap={2}
+                    >
+                      <Icon name="videocam" size={10} color="white" />
+                      <StyledText color="white" fontSize={10}>
+                        {formatDuration(item.duration)}
+                      </StyledText>
+                    </XStack>
+                  )}
+
+                  {/* Already-added overlay: dim + checkmark, not selectable */}
+                  {added && (
+                    <StyledView
+                      position="absolute"
+                      top={0}
+                      left={0}
+                      right={0}
+                      bottom={0}
+                      backgroundColor="rgba(0,0,0,0.55)"
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      <Icon
+                        name="checkmark-circle"
+                        type={IconType.Ionicons}
+                        size={28}
+                        color="white"
+                      />
+                      <StyledText color="white" fontSize={10} marginTop={2}>
+                        added
+                      </StyledText>
+                    </StyledView>
+                  )}
+
+                  {/* Selection badge */}
+                  {!added && (
+                    <StyledView
+                      position="absolute"
+                      top={6}
+                      right={6}
+                      width={22}
+                      height={22}
+                      borderRadius={11}
+                      borderWidth={1.5}
+                      borderColor="white"
+                      backgroundColor={isSelected ? "$orange9" : "rgba(0,0,0,0.25)"}
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      {isSelected && (
+                        <StyledText color="white" fontSize={11} bold>
+                          {selectionIndex + 1}
+                        </StyledText>
+                      )}
+                    </StyledView>
+                  )}
+                </Pressable>
+              );
+            }}
+          />
+        )}
+      </YStack>
+    </StyledView>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds || seconds < 0) {
+    return "0:00";
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -1,3 +1,4 @@
+import { Image as ExpoImage } from "expo-image";
 import * as MediaLibrary from "expo-media-library";
 import {
   memo,
@@ -11,7 +12,6 @@ import {
 import {
   Dimensions,
   FlatList,
-  Image,
   Linking,
   Modal,
   Platform,
@@ -300,7 +300,11 @@ export function CustomPhotoPicker({
               style={{ flex: 1 }}
               onEndReached={handleEndReached}
               onEndReachedThreshold={1.5}
-              removeClippedSubviews
+              // removeClippedSubviews drops the views of offscreen cells, and on
+              // iOS that intermittently leaves blank cells when they scroll back
+              // into view. Keep it on Android (stable + helps memory) but rely on
+              // expo-image's recycling on iOS instead.
+              removeClippedSubviews={Platform.OS === "android"}
               initialNumToRender={24}
               windowSize={5}
               contentContainerStyle={{
@@ -420,12 +424,24 @@ const PhotoCell = memo(function PhotoCell({
         height: cellSize,
         marginRight: CellGap,
         marginBottom: CellGap,
+        // Neutral backing so a not-yet-decoded cell reads as a gray tile rather
+        // than a blank white square while its thumbnail loads.
+        backgroundColor: "#3a3a3a",
       }}
     >
-      <Image
-        source={{ uri }}
+      <ExpoImage
+        source={uri}
         style={{ width: "100%", height: "100%" }}
-        resizeMode="cover"
+        contentFit="cover"
+        // PhotoKit (ph://) and remote thumbnails: request the small grid-sized
+        // representation, which iOS serves from its always-local thumbnail
+        // cache, so something shows even on a flaky/no connection (matching the
+        // native picker) instead of blocking on a full iCloud download.
+        recyclingKey={assetId}
+        cachePolicy="memory-disk"
+        transition={120}
+        allowDownscaling
+        priority="low"
       />
 
       {/* Video duration badge */}

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -332,10 +332,15 @@ export function CustomPhotoPicker({
               }
               maxToRenderPerBatch={12}
               getItemLayout={(_, index) => {
+                // With numColumns > 1, FlatList groups items into rows and calls
+                // getItemLayout with the ROW index (not the item index), so the
+                // offset is simply rowHeight * index. Dividing by NumColumns here
+                // would collapse every NumColumns rows onto one offset, corrupting
+                // the virtualization window and blanking cells as you scroll.
                 const rowHeight = cellSize + CellGap;
                 return {
                   length: rowHeight,
-                  offset: rowHeight * Math.floor(index / NumColumns),
+                  offset: rowHeight * index,
                   index,
                 };
               }}

--- a/components/CustomPhotoPicker.tsx
+++ b/components/CustomPhotoPicker.tsx
@@ -1,5 +1,6 @@
 import * as MediaLibrary from "expo-media-library";
 import {
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -300,7 +301,7 @@ export function CustomPhotoPicker({
               onEndReached={handleEndReached}
               onEndReachedThreshold={1.5}
               removeClippedSubviews
-              initialNumToRender={PageSize}
+              initialNumToRender={24}
               windowSize={5}
               contentContainerStyle={{
                 paddingBottom: 24,
@@ -325,94 +326,29 @@ export function CustomPhotoPicker({
                   </YStack>
                 ) : null
               }
+              maxToRenderPerBatch={12}
+              getItemLayout={(_, index) => {
+                const rowHeight = cellSize + CellGap;
+                return {
+                  length: rowHeight,
+                  offset: rowHeight * Math.floor(index / NumColumns),
+                  index,
+                };
+              }}
               renderItem={({ item }) => {
-                const added = isAdded(item.id);
                 const selectionIndex = selectedIds.indexOf(item.id);
-                const isSelected = selectionIndex !== -1;
                 return (
-                  <Pressable
-                    onPress={() => toggleSelect(item.id)}
-                    style={{
-                      width: cellSize,
-                      height: cellSize,
-                      marginRight: CellGap,
-                      marginBottom: CellGap,
-                    }}
-                  >
-                    <Image
-                      source={{ uri: item.uri }}
-                      style={{ width: "100%", height: "100%" }}
-                      resizeMode="cover"
-                    />
-
-                    {/* Video duration badge */}
-                    {item.mediaType === MediaLibrary.MediaType.video && (
-                      <XStack
-                        position="absolute"
-                        bottom={4}
-                        right={4}
-                        backgroundColor="rgba(0,0,0,0.6)"
-                        paddingHorizontal={4}
-                        borderRadius={4}
-                        alignItems="center"
-                        gap={2}
-                      >
-                        <Icon name="videocam" size={10} color="white" />
-                        <StyledText color="white" fontSize={10}>
-                          {formatDuration(item.duration)}
-                        </StyledText>
-                      </XStack>
-                    )}
-
-                    {/* Already-added overlay: dim + checkmark, not selectable */}
-                    {added && (
-                      <StyledView
-                        position="absolute"
-                        top={0}
-                        left={0}
-                        right={0}
-                        bottom={0}
-                        backgroundColor="rgba(0,0,0,0.55)"
-                        alignItems="center"
-                        justifyContent="center"
-                      >
-                        <Icon
-                          name="checkmark-circle"
-                          type={IconType.Ionicons}
-                          size={28}
-                          color="white"
-                        />
-                        <StyledText color="white" fontSize={10} marginTop={2}>
-                          added
-                        </StyledText>
-                      </StyledView>
-                    )}
-
-                    {/* Selection badge */}
-                    {!added && (
-                      <StyledView
-                        position="absolute"
-                        top={6}
-                        right={6}
-                        width={22}
-                        height={22}
-                        borderRadius={11}
-                        borderWidth={1.5}
-                        borderColor="white"
-                        backgroundColor={
-                          isSelected ? "$orange9" : "rgba(0,0,0,0.25)"
-                        }
-                        alignItems="center"
-                        justifyContent="center"
-                      >
-                        {isSelected && (
-                          <StyledText color="white" fontSize={11} bold>
-                            {selectionIndex + 1}
-                          </StyledText>
-                        )}
-                      </StyledView>
-                    )}
-                  </Pressable>
+                  <PhotoCell
+                    uri={item.uri}
+                    isVideo={item.mediaType === MediaLibrary.MediaType.video}
+                    duration={item.duration}
+                    added={isAdded(item.id)}
+                    isSelected={selectionIndex !== -1}
+                    selectionIndex={selectionIndex}
+                    cellSize={cellSize}
+                    assetId={item.id}
+                    onPress={toggleSelect}
+                  />
                 );
               }}
             />
@@ -452,6 +388,114 @@ export function CustomPhotoPicker({
     </Modal>
   );
 }
+
+// Memoized so selecting one photo only re-renders the cells whose state
+// actually changed, not the whole visible grid.
+const PhotoCell = memo(function PhotoCell({
+  uri,
+  isVideo,
+  duration,
+  added,
+  isSelected,
+  selectionIndex,
+  cellSize,
+  assetId,
+  onPress,
+}: {
+  uri: string;
+  isVideo: boolean;
+  duration: number;
+  added: boolean;
+  isSelected: boolean;
+  selectionIndex: number;
+  cellSize: number;
+  assetId: string;
+  onPress: (id: string) => void;
+}) {
+  return (
+    <Pressable
+      onPress={() => onPress(assetId)}
+      style={{
+        width: cellSize,
+        height: cellSize,
+        marginRight: CellGap,
+        marginBottom: CellGap,
+      }}
+    >
+      <Image
+        source={{ uri }}
+        style={{ width: "100%", height: "100%" }}
+        resizeMode="cover"
+      />
+
+      {/* Video duration badge */}
+      {isVideo && (
+        <XStack
+          position="absolute"
+          bottom={4}
+          right={4}
+          backgroundColor="rgba(0,0,0,0.6)"
+          paddingHorizontal={4}
+          borderRadius={4}
+          alignItems="center"
+          gap={2}
+        >
+          <Icon name="videocam" size={10} color="white" />
+          <StyledText color="white" fontSize={10}>
+            {formatDuration(duration)}
+          </StyledText>
+        </XStack>
+      )}
+
+      {/* Already-added overlay: dim + checkmark, not selectable */}
+      {added && (
+        <StyledView
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          backgroundColor="rgba(0,0,0,0.55)"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Icon
+            name="checkmark-circle"
+            type={IconType.Ionicons}
+            size={28}
+            color="white"
+          />
+          <StyledText color="white" fontSize={10} marginTop={2}>
+            added
+          </StyledText>
+        </StyledView>
+      )}
+
+      {/* Selection badge */}
+      {!added && (
+        <StyledView
+          position="absolute"
+          top={6}
+          right={6}
+          width={22}
+          height={22}
+          borderRadius={11}
+          borderWidth={1.5}
+          borderColor="white"
+          backgroundColor={isSelected ? "$orange9" : "rgba(0,0,0,0.25)"}
+          alignItems="center"
+          justifyContent="center"
+        >
+          {isSelected && (
+            <StyledText color="white" fontSize={11} bold>
+              {selectionIndex + 1}
+            </StyledText>
+          )}
+        </StyledView>
+      )}
+    </Pressable>
+  );
+});
 
 function formatDuration(seconds: number): string {
   if (!seconds || seconds < 0) {

--- a/components/MediaView.tsx
+++ b/components/MediaView.tsx
@@ -1,5 +1,6 @@
 import { BlockType, isBlockContentVideo } from "../utils/mimeTypes";
 import { StyledView, StyledText, Icon, AspectRatioImage } from "./Themed";
+import { PinchToZoom } from "./PinchToZoom";
 import { Pressable } from "react-native";
 import { Audio, ResizeMode, Video } from "expo-av";
 import {
@@ -23,6 +24,7 @@ export function MediaView({
   videoProps,
   children,
   isVisible = true,
+  zoomable = false,
 }: PropsWithChildren<{
   media: string;
   blockType: BlockType;
@@ -30,6 +32,7 @@ export function MediaView({
   style?: StyleProps;
   videoProps?: GetProps<typeof Video>;
   isVisible?: boolean;
+  zoomable?: boolean;
 }>) {
   const [sound, setSound] = useState<Audio.Sound | undefined>();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -94,7 +97,7 @@ export function MediaView({
             console.log(`FATAL PLAYER ERROR: ${status.error}`);
           }
         }
-      }
+      },
     );
     setSound(sound);
   }
@@ -123,8 +126,8 @@ export function MediaView({
             }}
           />
         ) : null;
-      case BlockType.Image:
-        return (
+      case BlockType.Image: {
+        const image = (
           <AspectRatioImage
             uri={media}
             // TODO: types
@@ -133,6 +136,8 @@ export function MediaView({
             }}
           />
         );
+        return zoomable ? <PinchToZoom>{image}</PinchToZoom> : image;
+      }
       case BlockType.Document:
         if (!mediaIsVideo) {
           return null;

--- a/components/PinchToZoom.tsx
+++ b/components/PinchToZoom.tsx
@@ -1,0 +1,63 @@
+import { PropsWithChildren } from "react";
+import { StyleProp, ViewStyle } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+// Pinch-to-zoom "peek": scales the wrapped content around the pinch focal point
+// while two fingers are down, then springs back to normal on release. Lets you
+// look in on an image in place without a separate fullscreen viewer.
+export function PinchToZoom({
+  children,
+  style,
+}: PropsWithChildren<{ style?: StyleProp<ViewStyle> }>) {
+  const scale = useSharedValue(1);
+  const focalX = useSharedValue(0);
+  const focalY = useSharedValue(0);
+  const width = useSharedValue(0);
+  const height = useSharedValue(0);
+
+  const pinch = Gesture.Pinch()
+    .onUpdate((e) => {
+      // Only allow zooming in, not shrinking below natural size.
+      scale.value = Math.max(1, e.scale);
+      focalX.value = e.focalX;
+      focalY.value = e.focalY;
+    })
+    .onEnd(() => {
+      scale.value = withTiming(1);
+    });
+
+  const animatedStyle = useAnimatedStyle(() => {
+    // Translate the focal point to the origin, scale, then translate back so the
+    // zoom centers on where the fingers are.
+    const offsetX = focalX.value - width.value / 2;
+    const offsetY = focalY.value - height.value / 2;
+    return {
+      transform: [
+        { translateX: offsetX },
+        { translateY: offsetY },
+        { scale: scale.value },
+        { translateX: -offsetX },
+        { translateY: -offsetY },
+      ],
+    };
+  });
+
+  return (
+    <GestureDetector gesture={pinch}>
+      <Animated.View
+        style={[style, animatedStyle]}
+        onLayout={(e) => {
+          width.value = e.nativeEvent.layout.width;
+          height.value = e.nativeEvent.layout.height;
+        }}
+      >
+        {children}
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/components/PinchToZoom.tsx
+++ b/components/PinchToZoom.tsx
@@ -1,34 +1,58 @@
-import { PropsWithChildren } from "react";
-import { StyleProp, ViewStyle } from "react-native";
+import { PropsWithChildren, useRef, useState } from "react";
+import { StyleProp, View, ViewStyle } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
+  runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
+import { Portal } from "tamagui";
 
-// Pinch-to-zoom "peek": scales the wrapped content around the pinch focal point
-// while two fingers are down, then springs back to normal on release. Lets you
-// look in on an image in place without a separate fullscreen viewer.
+// Pinch-to-zoom "peek": while two fingers are down the image is lifted into a
+// root-level Portal (so it renders above all other content instead of being
+// overlapped/clipped by siblings) and scaled around the pinch focal point, then
+// springs back and drops out of the portal on release.
 export function PinchToZoom({
   children,
   style,
 }: PropsWithChildren<{ style?: StyleProp<ViewStyle> }>) {
+  const containerRef = useRef<View>(null);
+  const [active, setActive] = useState(false);
+  const [rect, setRect] = useState({ x: 0, y: 0, width: 0, height: 0 });
+
   const scale = useSharedValue(1);
   const focalX = useSharedValue(0);
   const focalY = useSharedValue(0);
   const width = useSharedValue(0);
   const height = useSharedValue(0);
 
+  const onActivate = () => {
+    containerRef.current?.measureInWindow((x, y, w, h) => {
+      setRect({ x, y, width: w, height: h });
+      width.value = w;
+      height.value = h;
+      setActive(true);
+    });
+  };
+  const onDeactivate = () => setActive(false);
+
   const pinch = Gesture.Pinch()
+    .onStart(() => {
+      runOnJS(onActivate)();
+    })
     .onUpdate((e) => {
-      // Only allow zooming in, not shrinking below natural size.
+      // Only zoom in, never shrink below natural size.
       scale.value = Math.max(1, e.scale);
       focalX.value = e.focalX;
       focalY.value = e.focalY;
     })
-    .onEnd(() => {
-      scale.value = withTiming(1);
+    .onFinalize(() => {
+      scale.value = withTiming(1, { duration: 180 }, (finished) => {
+        if (finished) {
+          runOnJS(onDeactivate)();
+        }
+      });
     });
 
   const animatedStyle = useAnimatedStyle(() => {
@@ -49,15 +73,29 @@ export function PinchToZoom({
 
   return (
     <GestureDetector gesture={pinch}>
-      <Animated.View
-        style={[style, animatedStyle]}
-        onLayout={(e) => {
-          width.value = e.nativeEvent.layout.width;
-          height.value = e.nativeEvent.layout.height;
-        }}
-      >
-        {children}
-      </Animated.View>
+      <View ref={containerRef} collapsable={false} style={style}>
+        {/* Hide the inline copy while it's lifted into the portal. */}
+        <View style={{ opacity: active ? 0 : 1 }}>{children}</View>
+        {active && (
+          <Portal>
+            <Animated.View
+              pointerEvents="none"
+              style={[
+                {
+                  position: "absolute",
+                  left: rect.x,
+                  top: rect.y,
+                  width: rect.width,
+                  height: rect.height,
+                },
+                animatedStyle,
+              ]}
+            >
+              {children}
+            </Animated.View>
+          </Portal>
+        )}
+      </View>
     </GestureDetector>
   );
 }

--- a/components/TextForageView.tsx
+++ b/components/TextForageView.tsx
@@ -500,15 +500,27 @@ function TextForageViewContent({
       }
       setIsLoadingAssets(true);
       try {
-        const mediaWithMetadata = await Promise.all(
+        const results = await Promise.allSettled(
           assets.map(processPickedAsset)
         );
-        setMedias((prev) => [...prev, ...mediaWithMetadata]);
+        const mediaWithMetadata = results
+          .filter(
+            (r): r is PromiseFulfilledResult<PickedMedia> =>
+              r.status === "fulfilled"
+          )
+          .map((r) => r.value);
+        const failed = results.filter((r) => r.status === "rejected");
+        if (failed.length) {
+          logError((failed[0] as PromiseRejectedResult).reason);
+        }
+        if (mediaWithMetadata.length) {
+          setMedias((prev) => [...prev, ...mediaWithMetadata]);
+        }
       } finally {
         setIsLoadingAssets(false);
       }
     },
-    []
+    [logError]
   );
 
   function removeMedia(idx: number) {

--- a/components/TextForageView.tsx
+++ b/components/TextForageView.tsx
@@ -95,7 +95,7 @@ interface PickedMedia {
 
 const getLocationMetadata = async (
   latitude: number,
-  longitude: number
+  longitude: number,
 ): Promise<LocationMetadata> => {
   try {
     const results = await Location.reverseGeocodeAsync({ latitude, longitude });
@@ -137,12 +137,12 @@ const getCurrentLocationMetadata = async (): Promise<
 const parseExifDate = (dateString?: string): number | undefined => {
   if (!dateString) return undefined;
   return new Date(
-    dateString.replace(/^(\d{4}):(\d{2}):(\d{2})/, "$1-$2-$3")
+    dateString.replace(/^(\d{4}):(\d{2}):(\d{2})/, "$1-$2-$3"),
   ).getTime();
 };
 
 const processMediaAsset = async (
-  asset: ImagePicker.ImagePickerAsset
+  asset: ImagePicker.ImagePickerAsset,
 ): Promise<PickedMedia> => {
   let metadata = null;
   if (asset.exif) {
@@ -181,7 +181,7 @@ const processMediaAsset = async (
 
 const guessContentType = (
   filename: string | undefined,
-  mediaType: MediaLibrary.MediaTypeValue
+  mediaType: MediaLibrary.MediaTypeValue,
 ): MimeType | undefined => {
   const ext =
     filename && filename.includes(".")
@@ -200,14 +200,14 @@ const guessContentType = (
 // PickedMedia shape, pulling the local file uri plus capture time / location
 // the same way processMediaAsset does for the native picker.
 const processPickedAsset = async (
-  asset: MediaLibrary.Asset
+  asset: MediaLibrary.Asset,
 ): Promise<PickedMedia> => {
   const info = await MediaLibrary.getAssetInfoAsync(asset);
   let locationData: LocationMetadata | undefined;
   if (info.location) {
     locationData = await getLocationMetadata(
       info.location.latitude,
-      info.location.longitude
+      info.location.longitude,
     );
   }
   const isVideo = asset.mediaType === MediaLibrary.MediaType.video;
@@ -284,11 +284,11 @@ function TextForageViewContent({
 
   // @ mention autocomplete state
   const [selectedCollections, setSelectedCollections] = useState<Collection[]>(
-    []
+    [],
   );
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(
-    null
+    null,
   );
   const textInputRef = useRef<TextInput>(null);
 
@@ -303,7 +303,7 @@ function TextForageViewContent({
     if (!mentionCollections) return [];
     const selectedIds = new Set(selectedCollections.map((c) => c.id));
     return mentionCollections.filter(
-      (c) => !selectedIds.has(c.id) && c.id !== collectionId
+      (c) => !selectedIds.has(c.id) && c.id !== collectionId,
     );
   }, [mentionCollections, selectedCollections, collectionId]);
 
@@ -314,7 +314,7 @@ function TextForageViewContent({
       selectedCollections.some((c) => c.id === collectionId)
     ) {
       setSelectedCollections((prev) =>
-        prev.filter((c) => c.id !== collectionId)
+        prev.filter((c) => c.id !== collectionId),
       );
     }
   }, [collectionId]);
@@ -329,15 +329,15 @@ function TextForageViewContent({
           (Platform.OS === "android"
             ? messageBarKeyboardPadding
             : Platform.OS === "ios"
-            ? bottomTabHeight
-            : 0)
+              ? bottomTabHeight
+              : 0)
         : 0,
     };
   }, [keyboard.height, textFocused]);
 
   const updatePlaceholder = useCallback(() => {
     setTextPlaceholder(
-      placeholders[Math.floor(Math.random() * placeholders.length)]
+      placeholders[Math.floor(Math.random() * placeholders.length)],
     );
   }, []);
 
@@ -353,7 +353,7 @@ function TextForageViewContent({
       const collectionItemsText = collectionItems.map((item) =>
         item.content.length > MaxPlaceholderLength
           ? item.content.slice(0, MaxPlaceholderLength) + "..."
-          : item.content
+          : item.content,
       );
       console.log("collectionItemsText", collectionItemsText);
       if (collectionItemsText.length) {
@@ -367,7 +367,7 @@ function TextForageViewContent({
     void fetchPlaceholders().then((newPlaceholders) => {
       setPlaceholders(newPlaceholders);
       setTextPlaceholder(
-        newPlaceholders[Math.floor(Math.random() * newPlaceholders.length)]
+        newPlaceholders[Math.floor(Math.random() * newPlaceholders.length)],
       );
     });
   }, []);
@@ -412,7 +412,7 @@ function TextForageViewContent({
       setMentionStartIndex(lastAtIndex);
       setMentionQuery(query);
     },
-    [setTextValue]
+    [setTextValue],
   );
 
   // Handle selecting a collection from autocomplete
@@ -433,7 +433,7 @@ function TextForageViewContent({
       setMentionQuery(null);
       setMentionStartIndex(null);
     },
-    [mentionStartIndex, mentionQuery, textValue, setTextValueProgrammatic]
+    [mentionStartIndex, mentionQuery, textValue, setTextValueProgrammatic],
   );
 
   // Handle removing a selected collection
@@ -501,12 +501,12 @@ function TextForageViewContent({
       setIsLoadingAssets(true);
       try {
         const results = await Promise.allSettled(
-          assets.map(processPickedAsset)
+          assets.map(processPickedAsset),
         );
         const mediaWithMetadata = results
           .filter(
             (r): r is PromiseFulfilledResult<PickedMedia> =>
-              r.status === "fulfilled"
+              r.status === "fulfilled",
           )
           .map((r) => r.value);
         const failed = results.filter((r) => r.status === "rejected");
@@ -520,7 +520,7 @@ function TextForageViewContent({
         setIsLoadingAssets(false);
       }
     },
-    [logError]
+    [logError],
   );
 
   function removeMedia(idx: number) {
@@ -562,7 +562,7 @@ function TextForageViewContent({
               const fileUri = await getFsPathForMediaResult(
                 uri,
                 type === BlockType.Image ? "jpg" : "mp4",
-                assetId
+                assetId,
               );
               return {
                 createdBy: currentUser!.id,
@@ -576,8 +576,8 @@ function TextForageViewContent({
                 title: useTextAsMediaTitle ? savedTextValue.trim() : undefined,
                 collectionsToConnect,
               };
-            }
-          )
+            },
+          ),
         );
         blocksToInsert.push(...mediaToInsert);
       }
@@ -668,7 +668,7 @@ function TextForageViewContent({
 
       console.log("Starting recording..");
       const { recording } = await Audio.Recording.createAsync(
-        Audio.RecordingOptionsPresets.HIGH_QUALITY
+        Audio.RecordingOptionsPresets.HIGH_QUALITY,
       );
       setRecording(recording);
       console.log("Recording started");
@@ -736,7 +736,7 @@ function TextForageViewContent({
 
     if (!result.canceled) {
       const mediaWithMetadata = await Promise.all(
-        result.assets.map(processMediaAsset)
+        result.assets.map(processMediaAsset),
       );
 
       setMedias([...medias, ...mediaWithMetadata]);
@@ -748,7 +748,7 @@ function TextForageViewContent({
 
   async function checkExistingMedias(): Promise<Set<string>> {
     const existingMedias = await getExistingAssetIds(
-      medias.map(({ assetId }) => assetId)
+      medias.map(({ assetId }) => assetId),
     );
 
     return new Set(existingMedias);
@@ -1033,7 +1033,7 @@ function TextForageViewContent({
                           text: "Add Anyway",
                           onPress: () => onSaveResult(),
                         },
-                      ]
+                      ],
                     );
                   } else {
                     onSaveResult();

--- a/components/TextForageView.tsx
+++ b/components/TextForageView.tsx
@@ -1084,7 +1084,6 @@ function TextForageViewContent({
         onClose={() => setPickerVisible(false)}
         onConfirm={handlePickerConfirm}
         alreadyPickedAssetIds={medias.map((m) => m.assetId)}
-        topInset={insets.top}
         bottomInset={insets.bottom}
       />
     </StyledView>

--- a/components/TextForageView.tsx
+++ b/components/TextForageView.tsx
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { Audio } from "expo-av";
 import { Recording } from "expo-av/build/Audio";
 import * as ImagePicker from "expo-image-picker";
+import * as MediaLibrary from "expo-media-library";
 import {
   useCallback,
   useContext,
@@ -61,6 +62,7 @@ import * as Location from "expo-location";
 import { useLocation, LocationProvider } from "../utils/location";
 import { CollectionSummary } from "./CollectionSummary";
 import { CollectionSelect } from "./CollectionSelect";
+import { CustomPhotoPicker } from "./CustomPhotoPicker";
 
 const DefaultPlaceholders = [
   "Who do you love and why?",
@@ -174,6 +176,48 @@ const processMediaAsset = async (
     contentType: asset.mimeType as MimeType,
     assetId: asset.assetId,
     ...metadata,
+  };
+};
+
+const guessContentType = (
+  filename: string | undefined,
+  mediaType: MediaLibrary.MediaTypeValue
+): MimeType | undefined => {
+  const ext =
+    filename && filename.includes(".")
+      ? "." + filename.split(".").pop()!.toLowerCase()
+      : "";
+  const mime = (MimeType as Record<string, string>)[ext];
+  if (mime) {
+    return mime as MimeType;
+  }
+  return mediaType === MediaLibrary.MediaType.video
+    ? (MimeType[".mp4"] as MimeType)
+    : (MimeType[".jpg"] as MimeType);
+};
+
+// Convert a device media-library asset (from our custom picker) into the
+// PickedMedia shape, pulling the local file uri plus capture time / location
+// the same way processMediaAsset does for the native picker.
+const processPickedAsset = async (
+  asset: MediaLibrary.Asset
+): Promise<PickedMedia> => {
+  const info = await MediaLibrary.getAssetInfoAsync(asset);
+  let locationData: LocationMetadata | undefined;
+  if (info.location) {
+    locationData = await getLocationMetadata(
+      info.location.latitude,
+      info.location.longitude
+    );
+  }
+  const isVideo = asset.mediaType === MediaLibrary.MediaType.video;
+  return {
+    uri: info.localUri || asset.uri,
+    type: isVideo ? BlockType.Video : BlockType.Image,
+    contentType: guessContentType(asset.filename, asset.mediaType),
+    assetId: asset.id,
+    captureTime: info.creationTime || asset.creationTime,
+    locationData,
   };
 };
 
@@ -446,25 +490,26 @@ function TextForageViewContent({
     fetchNextPage();
   }
 
-  const pickImage = async () => {
-    setIsLoadingAssets(true);
-    let result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.All,
-      allowsMultipleSelection: true,
-      quality: 1,
-      orderedSelection: true,
-      exif: true,
-    });
+  const [pickerVisible, setPickerVisible] = useState(false);
 
-    if (!result.canceled) {
-      const mediaWithMetadata = await Promise.all(
-        result.assets.map(processMediaAsset)
-      );
-
-      setMedias([...medias, ...mediaWithMetadata]);
-    }
-    setIsLoadingAssets(false);
-  };
+  const handlePickerConfirm = useCallback(
+    async (assets: MediaLibrary.Asset[]) => {
+      setPickerVisible(false);
+      if (!assets.length) {
+        return;
+      }
+      setIsLoadingAssets(true);
+      try {
+        const mediaWithMetadata = await Promise.all(
+          assets.map(processPickedAsset)
+        );
+        setMedias((prev) => [...prev, ...mediaWithMetadata]);
+      } finally {
+        setIsLoadingAssets(false);
+      }
+    },
+    []
+  );
 
   function removeMedia(idx: number) {
     setMedias(medias.filter((_, i) => i !== idx));
@@ -943,7 +988,7 @@ function TextForageViewContent({
             /> */}
             <StyledButton
               icon={<Icon size={24} name="images" />}
-              onPress={pickImage}
+              onPress={() => setPickerVisible(true)}
               paddingHorizontal="$1"
               theme="grey"
               chromeless
@@ -1022,6 +1067,12 @@ function TextForageViewContent({
           </XStack>
         </YStack>
       </Animated.View>
+      <CustomPhotoPicker
+        visible={pickerVisible}
+        onClose={() => setPickerVisible(false)}
+        onConfirm={handlePickerConfirm}
+        alreadyPickedAssetIds={medias.map((m) => m.assetId)}
+      />
     </StyledView>
   );
 }

--- a/components/TextForageView.tsx
+++ b/components/TextForageView.tsx
@@ -1084,6 +1084,8 @@ function TextForageViewContent({
         onClose={() => setPickerVisible(false)}
         onConfirm={handlePickerConfirm}
         alreadyPickedAssetIds={medias.map((m) => m.assetId)}
+        topInset={insets.top}
+        bottomInset={insets.bottom}
       />
     </StyledView>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "expo-file-system": "~16.0.9",
         "expo-font": "~11.10.3",
         "expo-haptics": "~12.8.1",
+        "expo-image": "~1.10.6",
         "expo-image-picker": "~14.7.1",
         "expo-linking": "~6.2.2",
         "expo-location": "~16.5.5",
@@ -8604,6 +8605,18 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-image": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-1.10.6.tgz",
+      "integrity": "sha512-vcnAIym1eU8vQgV1re1E7rVQZStJimBa4aPDhjFfzMzbddAF7heJuagyewiUkTzbZUwYzPaZAie6VJPyWx9Ueg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/assets-registry": "~0.73.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-image-loader": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.6.0.tgz",
@@ -14218,7 +14231,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo-file-system": "~16.0.9",
     "expo-font": "~11.10.3",
     "expo-haptics": "~12.8.1",
+    "expo-image": "~1.10.6",
     "expo-image-picker": "~14.7.1",
     "expo-linking": "~6.2.2",
     "expo-location": "~16.5.5",

--- a/tamagui.config.ts
+++ b/tamagui.config.ts
@@ -56,8 +56,11 @@ const bodyFont = createInterFont(
   },
   {
     sizeSize: (size) => Math.round(size * 1.1),
-    sizeLineHeight: (size) => Math.round(size * 1.1),
-  }
+    // lineHeight needs headroom above fontSize or tall/bold glyphs clip at the
+    // top. This previously matched sizeSize exactly (zero leading) — the
+    // recurring cause of clipped header text. Scale it ~1.27x the font size.
+    sizeLineHeight: (size) => Math.round(size * 1.4),
+  },
 );
 
 export const config = createTamagui({

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -299,40 +299,20 @@ export function UncategorizedView() {
     >
       <Animated.View style={{ ...translateStyle }}>
         <Stack minHeight="100%">
-          {/* Focused (swipe) / Grid view toggle */}
-          <XStack
+          {/* Focused (swipe) / Grid view toggle — matches the Review view's
+              single toggle button that swaps icons. */}
+          <StyledButton
             position="absolute"
-            top={6}
-            left={8}
+            top={8}
+            left={10}
             zIndex={10}
-            backgroundColor="$gray4"
-            borderRadius={26}
-            padding={4}
-            gap={4}
-          >
-            <StyledButton
-              circular
-              size="$4"
-              chromeless={viewMode !== "swipe"}
-              theme={viewMode === "swipe" ? "orange" : undefined}
-              backgroundColor={
-                viewMode === "swipe" ? "$background" : "transparent"
-              }
-              icon={<Icon name="albums" size={22} />}
-              onPress={() => setViewMode("swipe")}
-            />
-            <StyledButton
-              circular
-              size="$4"
-              chromeless={viewMode !== "grid"}
-              theme={viewMode === "grid" ? "orange" : undefined}
-              backgroundColor={
-                viewMode === "grid" ? "$background" : "transparent"
-              }
-              icon={<Icon name="grid" size={22} />}
-              onPress={() => setViewMode("grid")}
-            />
-          </XStack>
+            size="$small"
+            backgroundColor="$gray6"
+            icon={<Icon name={viewMode === "swipe" ? "grid" : "image"} />}
+            onPress={() =>
+              setViewMode((m) => (m === "swipe" ? "grid" : "swipe"))
+            }
+          />
 
           {viewMode === "swipe" ? (
             <XStack

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -173,6 +173,7 @@ export function UncategorizedView() {
           block={block}
           key={block.id}
           editable={true}
+          zoomable
           style={{
             height: "100%",
             width: "100%",

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -8,8 +8,10 @@ import { Block } from "../utils/dataTypes";
 import { Icon, StyledButton, StyledText } from "../components/Themed";
 import {
   Dimensions,
+  FlatList,
   Keyboard,
   Platform,
+  Pressable,
   SafeAreaView,
   ViewToken,
 } from "react-native";
@@ -32,6 +34,8 @@ import Animated, {
 } from "react-native-reanimated";
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 
+const GridGap = 3;
+
 export function UncategorizedView() {
   const { addConnections, deleteBlock } = useContext(DatabaseContext);
   const { currentUser } = useContext(UserContext);
@@ -42,6 +46,23 @@ export function UncategorizedView() {
   const [lastSwipeDirection, setLastSwipeDirection] = useState<"next" | "prev">(
     "next"
   );
+  const [viewMode, setViewMode] = useState<"swipe" | "grid">("swipe");
+  // Blocks multi-selected in grid mode for bulk-connecting to collections.
+  const [selectedBlockIds, setSelectedBlockIds] = useState<Set<string>>(
+    new Set()
+  );
+
+  const toggleBlockSelection = useCallback((blockId: string) => {
+    setSelectedBlockIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(blockId)) {
+        next.delete(blockId);
+      } else {
+        next.add(blockId);
+      }
+      return next;
+    });
+  }, []);
 
   const renderBlock = useCallback(
     (block: Block, idx: number) => {
@@ -98,6 +119,7 @@ export function UncategorizedView() {
   );
 
   const width = Dimensions.get("window").width;
+  const gridCellSize = Math.floor(width / 3) - GridGap * 2;
   const carouselRef = useRef<ICarouselInstance>(null);
   const [selectedCollections, setSelectedCollections] = useState<string[]>([]);
   const [searchValue, setSearchValue] = useState("");
@@ -111,6 +133,37 @@ export function UncategorizedView() {
     },
     [events]
   );
+
+  // Connect every grid-selected block to the chosen collections at once.
+  const handleBulkConnect = useCallback(async () => {
+    if (selectedBlockIds.size === 0 || selectedCollections.length === 0) {
+      return;
+    }
+    Keyboard.dismiss();
+    await Promise.all(
+      Array.from(selectedBlockIds).map((blockId) =>
+        addConnections({
+          blockId,
+          connections: selectedCollections.map((c) => ({
+            collectionId: c,
+            createdBy: currentUser!.id,
+          })),
+        })
+      )
+    );
+    setSelectedBlockIds(new Set());
+    setSelectedCollections([]);
+    setSearchValue("");
+  }, [selectedBlockIds, selectedCollections, addConnections, currentUser]);
+
+  // Jump the swipe carousel straight to a block tapped in the grid.
+  const jumpToSwipe = useCallback((index: number) => {
+    setCurrentIdx(index);
+    setViewMode("swipe");
+    requestAnimationFrame(() => {
+      carouselRef.current?.scrollTo({ index, animated: false });
+    });
+  }, []);
 
   function CarouselItem({ item, index }: { item: Block; index: number }) {
     if (!events) {
@@ -246,37 +299,193 @@ export function UncategorizedView() {
     >
       <Animated.View style={{ ...translateStyle }}>
         <Stack minHeight="100%">
-          <XStack flex={1} flexGrow={1} onTouchMove={() => Keyboard.dismiss()}>
-            <Carousel
-              ref={carouselRef}
-              loop={false}
-              // TODO: this isn't actually available in this source in this version but seemingly does something? i literally have no idea why
-              // @ts-ignore
-              minScrollDistancePerSwipe={0.1}
-              withAnimation={{
-                type: "spring",
-                config: {
-                  damping: 40,
-                  mass: 1.2,
-                  stiffness: 250,
-                },
-              }}
-              snapEnabled
-              width={width}
-              data={events}
-              windowSize={5}
-              renderItem={({ item, index }) => CarouselItem({ item, index })}
-              onSnapToItem={(index) => {
-                if (index > currentIdx) {
-                  setLastSwipeDirection("next");
-                } else if (index < currentIdx) {
-                  setLastSwipeDirection("prev");
-                }
-                setCurrentIdx(index);
-              }}
+          {/* Swipe / Grid view toggle */}
+          <XStack
+            position="absolute"
+            top={4}
+            right={8}
+            zIndex={10}
+            backgroundColor="$gray3"
+            borderRadius={20}
+            padding={2}
+            gap={2}
+          >
+            <StyledButton
+              size="$2"
+              circular
+              chromeless
+              backgroundColor={viewMode === "swipe" ? "$background" : "transparent"}
+              icon={<Icon name="albums" size={18} />}
+              onPress={() => setViewMode("swipe")}
+            />
+            <StyledButton
+              size="$2"
+              circular
+              chromeless
+              backgroundColor={viewMode === "grid" ? "$background" : "transparent"}
+              icon={<Icon name="grid" size={18} />}
+              onPress={() => setViewMode("grid")}
             />
           </XStack>
+
+          {viewMode === "swipe" ? (
+            <XStack flex={1} flexGrow={1} onTouchMove={() => Keyboard.dismiss()}>
+              <Carousel
+                ref={carouselRef}
+                loop={false}
+                // TODO: this isn't actually available in this source in this version but seemingly does something? i literally have no idea why
+                // @ts-ignore
+                minScrollDistancePerSwipe={0.1}
+                withAnimation={{
+                  type: "spring",
+                  config: {
+                    damping: 40,
+                    mass: 1.2,
+                    stiffness: 250,
+                  },
+                }}
+                snapEnabled
+                width={width}
+                data={events}
+                windowSize={5}
+                renderItem={({ item, index }) => CarouselItem({ item, index })}
+                onSnapToItem={(index) => {
+                  if (index > currentIdx) {
+                    setLastSwipeDirection("next");
+                  } else if (index < currentIdx) {
+                    setLastSwipeDirection("prev");
+                  }
+                  setCurrentIdx(index);
+                }}
+              />
+            </XStack>
+          ) : (
+            <YStack flex={1} flexGrow={1}>
+              <StyledText textAlign="center" marginTop="$1.5" marginBottom="$1">
+                {events.length} unconnected,{" "}
+                {totalBlocks === null ? "..." : totalBlocks} total
+              </StyledText>
+              <FlatList
+                data={events}
+                keyExtractor={(item) => item.id}
+                numColumns={3}
+                onTouchMove={() => Keyboard.dismiss()}
+                contentContainerStyle={{
+                  paddingHorizontal: GridGap,
+                  paddingBottom: 16,
+                }}
+                renderItem={({ item, index }) => {
+                  const selected = selectedBlockIds.has(item.id);
+                  return (
+                    <Pressable
+                      onPress={() => toggleBlockSelection(item.id)}
+                      style={{
+                        width: gridCellSize,
+                        height: gridCellSize,
+                        margin: GridGap,
+                      }}
+                    >
+                      <YStack
+                        width="100%"
+                        height="100%"
+                        borderRadius={8}
+                        overflow="hidden"
+                        backgroundColor="$gray3"
+                        borderWidth={2}
+                        borderColor={selected ? "$orange9" : "transparent"}
+                        justifyContent="center"
+                        alignItems="center"
+                      >
+                        <BlockSummary
+                          block={item}
+                          hideHoldMenu
+                          hideMetadata
+                          editable={false}
+                          isVisible={false}
+                          containerProps={{
+                            width: "100%",
+                            height: "100%",
+                            gap: 0,
+                            justifyContent: "center",
+                          }}
+                          style={{ width: "100%", height: "100%" }}
+                          blockStyle={{ resizeMode: "cover" }}
+                        />
+                      </YStack>
+                      {/* Selection badge */}
+                      <YStack
+                        position="absolute"
+                        top={6}
+                        right={6}
+                        width={22}
+                        height={22}
+                        borderRadius={11}
+                        borderWidth={1.5}
+                        borderColor="white"
+                        backgroundColor={
+                          selected ? "$orange9" : "rgba(0,0,0,0.25)"
+                        }
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        {selected && (
+                          <Icon name="checkmark" color="white" size={14} />
+                        )}
+                      </YStack>
+                      {/* Jump to this item in swipe view */}
+                      <StyledButton
+                        position="absolute"
+                        bottom={4}
+                        right={4}
+                        size="$1"
+                        circular
+                        chromeless
+                        backgroundColor="rgba(0,0,0,0.45)"
+                        icon={<Icon name="expand" color="white" size={12} />}
+                        onPress={() => jumpToSwipe(index)}
+                      />
+                    </Pressable>
+                  );
+                }}
+              />
+            </YStack>
+          )}
+
           <Stack paddingHorizontal="$1">
+            {viewMode === "grid" && selectedBlockIds.size > 0 && (
+              <XStack
+                paddingHorizontal="$2"
+                paddingVertical="$1.5"
+                gap="$2"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <StyledText>{selectedBlockIds.size} selected</StyledText>
+                <XStack gap="$2" alignItems="center">
+                  <StyledButton
+                    theme="red"
+                    circular
+                    size="$small"
+                    icon={<Icon name="close" />}
+                    onPress={() => setSelectedBlockIds(new Set())}
+                  />
+                  <StyledButton
+                    size="$medium"
+                    borderRadius={20}
+                    disabled={selectedCollections.length === 0}
+                    opacity={selectedCollections.length === 0 ? 0.5 : 1}
+                    onPress={handleBulkConnect}
+                    iconAfter={
+                      <SizableText>
+                        ({selectedCollections.length.toString()})
+                      </SizableText>
+                    }
+                  >
+                    Connect
+                  </StyledButton>
+                </XStack>
+              </XStack>
+            )}
             <SelectCollectionsList
               searchValue={searchValue}
               setSearchValue={setSearchValue}

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -303,8 +303,8 @@ export function UncategorizedView() {
               single toggle button that swaps icons. */}
           <StyledButton
             position="absolute"
-            top={8}
-            left={10}
+            top={6}
+            left={6}
             zIndex={10}
             size="$small"
             backgroundColor="$gray6"

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -457,14 +457,14 @@ export function UncategorizedView() {
                       {/* Open this item in the focused carousel (secondary) */}
                       <StyledButton
                         position="absolute"
-                        bottom={4}
-                        right={4}
-                        size="$2"
+                        bottom={6}
+                        right={6}
+                        size="$3"
                         circular
-                        chromeless
-                        backgroundColor="rgba(0,0,0,0.5)"
+                        backgroundColor="rgba(0,0,0,0.65)"
+                        pressStyle={{ backgroundColor: "rgba(0,0,0,0.85)" }}
                         icon={
-                          <Icon name="scan-outline" color="white" size={16} />
+                          <Icon name="expand" color="white" size={26} />
                         }
                         onPress={() => openInCarousel(index)}
                       />

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -7,6 +7,7 @@ import {
 import { Block } from "../utils/dataTypes";
 import {
   Icon,
+  IconType,
   StyledButton,
   StyledInput,
   StyledText,
@@ -459,12 +460,9 @@ export function UncategorizedView() {
                         position="absolute"
                         bottom={6}
                         right={6}
-                        size="$3"
-                        circular
-                        backgroundColor="rgba(0,0,0,0.65)"
-                        pressStyle={{ backgroundColor: "rgba(0,0,0,0.85)" }}
+                        size="$small"
                         icon={
-                          <Icon name="expand" color="white" size={26} />
+                          <Icon name="expand" type={IconType.FontAwesomeIcon} />
                         }
                         onPress={() => openInCarousel(index)}
                       />
@@ -484,28 +482,25 @@ export function UncategorizedView() {
                 alignItems="center"
                 justifyContent="space-between"
               >
-                <StyledText>{selectedBlockIds.size} selected</StyledText>
-                <XStack gap="$2" alignItems="center">
+                <XStack gap="$1.5" alignItems="center">
                   <StyledButton
-                    theme="red"
-                    circular
                     size="$small"
                     icon={<Icon name="close" />}
                     onPress={() => setSelectedBlockIds(new Set())}
                   />
+                  <StyledText>{selectedBlockIds.size} selected</StyledText>
+                </XStack>
+                <XStack gap="$2" alignItems="center">
                   <StyledButton
-                    size="$medium"
-                    borderRadius={20}
+                    size="$small"
                     icon={<Icon name="pencil" />}
                     onPress={() => {
                       setBulkTitleValue("");
                       setBulkTitleVisible(true);
                     }}
-                  >
-                    Title
-                  </StyledButton>
+                  />
                   <StyledButton
-                    size="$medium"
+                    size="$small"
                     borderRadius={20}
                     disabled={selectedCollections.length === 0}
                     opacity={selectedCollections.length === 0 ? 0.5 : 1}

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -5,7 +5,7 @@ import {
   useUncategorizedBlocks,
 } from "../utils/db";
 import { Block } from "../utils/dataTypes";
-import { Icon, StyledButton, StyledText } from "../components/Themed";
+import { Icon, IconType, StyledButton, StyledText } from "../components/Themed";
 import {
   Dimensions,
   FlatList,
@@ -44,12 +44,12 @@ export function UncategorizedView() {
   const bottomTabHeight = useBottomTabBarHeight();
   const [currentIdx, setCurrentIdx] = useState(0);
   const [lastSwipeDirection, setLastSwipeDirection] = useState<"next" | "prev">(
-    "next"
+    "next",
   );
   const [viewMode, setViewMode] = useState<"swipe" | "grid">("swipe");
   // Blocks multi-selected in grid mode for bulk-connecting to collections.
   const [selectedBlockIds, setSelectedBlockIds] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
 
   const toggleBlockSelection = useCallback((blockId: string) => {
@@ -90,7 +90,7 @@ export function UncategorizedView() {
         />
       );
     },
-    [currentIdx]
+    [currentIdx],
   );
 
   const onClickConnect = useCallback(
@@ -115,7 +115,7 @@ export function UncategorizedView() {
       }
       Keyboard.dismiss();
     },
-    [events, lastSwipeDirection]
+    [events, lastSwipeDirection],
   );
 
   const width = Dimensions.get("window").width;
@@ -131,7 +131,7 @@ export function UncategorizedView() {
       }
       await deleteBlock(blockId);
     },
-    [events]
+    [events],
   );
 
   // Connect every grid-selected block to the chosen collections at once.
@@ -148,8 +148,8 @@ export function UncategorizedView() {
             collectionId: c,
             createdBy: currentUser!.id,
           })),
-        })
-      )
+        }),
+      ),
     );
     setSelectedBlockIds(new Set());
     setSelectedCollections([]);
@@ -260,8 +260,8 @@ export function UncategorizedView() {
                 (Platform.OS === "android"
                   ? 40
                   : Platform.OS === "ios"
-                  ? bottomTabHeight
-                  : 0)
+                    ? bottomTabHeight
+                    : 0)
               )
             : 0,
         },
@@ -299,39 +299,51 @@ export function UncategorizedView() {
     >
       <Animated.View style={{ ...translateStyle }}>
         <Stack minHeight="100%">
-          {/* Swipe / Grid view toggle */}
+          {/* Focused (swipe) / Grid view toggle */}
           <XStack
             position="absolute"
             top={6}
             left={8}
             zIndex={10}
             backgroundColor="$gray4"
-            borderRadius={22}
-            padding={3}
-            gap={3}
+            borderRadius={26}
+            padding={4}
+            gap={4}
           >
             <StyledButton
               circular
-              size="$3"
+              size="$4"
               chromeless={viewMode !== "swipe"}
               theme={viewMode === "swipe" ? "orange" : undefined}
-              backgroundColor={viewMode === "swipe" ? "$background" : "transparent"}
-              icon={<Icon name="albums" size={22} />}
+              backgroundColor={
+                viewMode === "swipe" ? "$background" : "transparent"
+              }
+              icon={
+                <Icon name="square" type={IconType.FontAwesomeIcon} size={24} />
+              }
               onPress={() => setViewMode("swipe")}
             />
             <StyledButton
               circular
-              size="$3"
+              size="$4"
               chromeless={viewMode !== "grid"}
               theme={viewMode === "grid" ? "orange" : undefined}
-              backgroundColor={viewMode === "grid" ? "$background" : "transparent"}
-              icon={<Icon name="grid" size={22} />}
+              backgroundColor={
+                viewMode === "grid" ? "$background" : "transparent"
+              }
+              icon={
+                <Icon name="th" type={IconType.FontAwesomeIcon} size={24} />
+              }
               onPress={() => setViewMode("grid")}
             />
           </XStack>
 
           {viewMode === "swipe" ? (
-            <XStack flex={1} flexGrow={1} onTouchMove={() => Keyboard.dismiss()}>
+            <XStack
+              flex={1}
+              flexGrow={1}
+              onTouchMove={() => Keyboard.dismiss()}
+            >
               <Carousel
                 ref={carouselRef}
                 loop={false}

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -5,11 +5,17 @@ import {
   useUncategorizedBlocks,
 } from "../utils/db";
 import { Block } from "../utils/dataTypes";
-import { Icon, StyledButton, StyledText } from "../components/Themed";
+import {
+  Icon,
+  StyledButton,
+  StyledInput,
+  StyledText,
+} from "../components/Themed";
 import {
   Dimensions,
   FlatList,
   Keyboard,
+  Modal,
   Platform,
   Pressable,
   SafeAreaView,
@@ -37,7 +43,8 @@ import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 const GridGap = 3;
 
 export function UncategorizedView() {
-  const { addConnections, deleteBlock } = useContext(DatabaseContext);
+  const { addConnections, deleteBlock, updateBlock } =
+    useContext(DatabaseContext);
   const { currentUser } = useContext(UserContext);
   const { data: totalBlocks } = useTotalBlockCount();
   const { data: events } = useUncategorizedBlocks();
@@ -46,11 +53,15 @@ export function UncategorizedView() {
   const [lastSwipeDirection, setLastSwipeDirection] = useState<"next" | "prev">(
     "next",
   );
-  const [viewMode, setViewMode] = useState<"swipe" | "grid">("swipe");
-  // Blocks multi-selected in grid mode for bulk-connecting to collections.
+  // Grid is the default home view; you drill into the carousel to focus one item.
+  const [viewMode, setViewMode] = useState<"swipe" | "grid">("grid");
+  // Blocks multi-selected in grid mode for bulk actions (connect / title).
   const [selectedBlockIds, setSelectedBlockIds] = useState<Set<string>>(
     new Set(),
   );
+  // Bulk-title dialog state.
+  const [bulkTitleVisible, setBulkTitleVisible] = useState(false);
+  const [bulkTitleValue, setBulkTitleValue] = useState("");
 
   const toggleBlockSelection = useCallback((blockId: string) => {
     setSelectedBlockIds((prev) => {
@@ -156,8 +167,25 @@ export function UncategorizedView() {
     setSearchValue("");
   }, [selectedBlockIds, selectedCollections, addConnections, currentUser]);
 
-  // Jump the swipe carousel straight to a block tapped in the grid.
-  const jumpToSwipe = useCallback((index: number) => {
+  // Apply a single title to every grid-selected block.
+  const handleBulkTitle = useCallback(async () => {
+    const title = bulkTitleValue.trim();
+    if (!title || selectedBlockIds.size === 0) {
+      setBulkTitleVisible(false);
+      return;
+    }
+    await Promise.all(
+      Array.from(selectedBlockIds).map((blockId) =>
+        updateBlock({ blockId, editInfo: { title } }),
+      ),
+    );
+    setBulkTitleValue("");
+    setBulkTitleVisible(false);
+    setSelectedBlockIds(new Set());
+  }, [bulkTitleValue, selectedBlockIds, updateBlock]);
+
+  // Open a block from the grid in the focused carousel ("drill in").
+  const openInCarousel = useCallback((index: number) => {
     setCurrentIdx(index);
     setViewMode("swipe");
     requestAnimationFrame(() => {
@@ -278,22 +306,25 @@ export function UncategorizedView() {
     >
       <Animated.View style={{ ...translateStyle }}>
         <Stack minHeight="100%">
-          {/* Header row: view toggle · count · delete (single flex row so the
-              toggle and trash always line up). */}
+          {/* Header row. Grid is home; the carousel is a drill-in with a back
+              button to return. Single flex row keeps the buttons aligned. */}
           <XStack
             alignItems="center"
             paddingHorizontal={6}
             paddingTop={6}
             gap="$2"
           >
-            <StyledButton
-              size="$small"
-              backgroundColor="$gray6"
-              icon={<Icon name={viewMode === "swipe" ? "grid" : "image"} />}
-              onPress={() =>
-                setViewMode((m) => (m === "swipe" ? "grid" : "swipe"))
-              }
-            />
+            {viewMode === "swipe" ? (
+              <StyledButton
+                size="$small"
+                backgroundColor="$gray6"
+                icon={<Icon name="chevron-back" />}
+                onPress={() => setViewMode("grid")}
+              />
+            ) : (
+              // Spacer to keep the count centered.
+              <Stack width={40} />
+            )}
             <StyledText flex={1} textAlign="center">
               {viewMode === "swipe" ? `${currentIdx + 1} / ` : ""}
               {events.length} unconnected,{" "}
@@ -326,6 +357,8 @@ export function UncategorizedView() {
               <Carousel
                 ref={carouselRef}
                 loop={false}
+                // Open at the drilled-in item when entering from the grid.
+                defaultIndex={currentIdx}
                 // TODO: this isn't actually available in this source in this version but seemingly does something? i literally have no idea why
                 // @ts-ignore
                 minScrollDistancePerSwipe={0.1}
@@ -421,17 +454,19 @@ export function UncategorizedView() {
                           <Icon name="checkmark" color="white" size={14} />
                         )}
                       </YStack>
-                      {/* Jump to this item in swipe view */}
+                      {/* Open this item in the focused carousel (secondary) */}
                       <StyledButton
                         position="absolute"
                         bottom={4}
                         right={4}
-                        size="$1"
+                        size="$2"
                         circular
                         chromeless
-                        backgroundColor="rgba(0,0,0,0.45)"
-                        icon={<Icon name="expand" color="white" size={12} />}
-                        onPress={() => jumpToSwipe(index)}
+                        backgroundColor="rgba(0,0,0,0.5)"
+                        icon={
+                          <Icon name="scan-outline" color="white" size={16} />
+                        }
+                        onPress={() => openInCarousel(index)}
                       />
                     </Pressable>
                   );
@@ -458,6 +493,17 @@ export function UncategorizedView() {
                     icon={<Icon name="close" />}
                     onPress={() => setSelectedBlockIds(new Set())}
                   />
+                  <StyledButton
+                    size="$medium"
+                    borderRadius={20}
+                    icon={<Icon name="pencil" />}
+                    onPress={() => {
+                      setBulkTitleValue("");
+                      setBulkTitleVisible(true);
+                    }}
+                  >
+                    Title
+                  </StyledButton>
                   <StyledButton
                     size="$medium"
                     borderRadius={20}
@@ -488,6 +534,59 @@ export function UncategorizedView() {
           </Stack>
         </Stack>
       </Animated.View>
+
+      {/* Bulk-title dialog: one title applied to all selected items */}
+      <Modal
+        visible={bulkTitleVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setBulkTitleVisible(false)}
+      >
+        <YStack
+          flex={1}
+          backgroundColor="rgba(0,0,0,0.4)"
+          justifyContent="center"
+          alignItems="center"
+          paddingHorizontal="$4"
+        >
+          <YStack
+            width="100%"
+            maxWidth={360}
+            backgroundColor="$background"
+            borderRadius={16}
+            padding="$4"
+            gap="$3"
+          >
+            <StyledText bold fontSize="$5">
+              Title {selectedBlockIds.size} item
+              {selectedBlockIds.size > 1 ? "s" : ""}
+            </StyledText>
+            <StyledInput
+              value={bulkTitleValue}
+              onChangeText={setBulkTitleValue}
+              placeholder="Enter a title for all selected"
+              autoFocus
+              onSubmitEditing={handleBulkTitle}
+            />
+            <XStack gap="$2" justifyContent="flex-end">
+              <StyledButton
+                chromeless
+                onPress={() => setBulkTitleVisible(false)}
+              >
+                Cancel
+              </StyledButton>
+              <StyledButton
+                theme="green"
+                disabled={!bulkTitleValue.trim()}
+                opacity={!bulkTitleValue.trim() ? 0.5 : 1}
+                onPress={handleBulkTitle}
+              >
+                Apply
+              </StyledButton>
+            </XStack>
+          </YStack>
+        </YStack>
+      </Modal>
     </SafeAreaView>
   );
 }

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -558,16 +558,20 @@ export function UncategorizedView() {
                 </XStack>
               </XStack>
             )}
-            <SelectCollectionsList
-              searchValue={searchValue}
-              setSearchValue={setSearchValue}
-              selectedCollections={selectedCollections}
-              setSelectedCollections={setSelectedCollections}
-              horizontal
-              onFocusInputChange={(isFocused) =>
-                setCollectionsSelectInputFocused(isFocused)
-              }
-            />
+            {/* In grid view, hide the collection picker until items are
+                selected so the grid is unobstructed while navigating. */}
+            {(viewMode === "swipe" || selectedBlockIds.size > 0) && (
+              <SelectCollectionsList
+                searchValue={searchValue}
+                setSearchValue={setSearchValue}
+                selectedCollections={selectedCollections}
+                setSelectedCollections={setSelectedCollections}
+                horizontal
+                onFocusInputChange={(isFocused) =>
+                  setCollectionsSelectInputFocused(isFocused)
+                }
+              />
+            )}
           </Stack>
         </Stack>
       </Animated.View>

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -535,6 +535,7 @@ export function UncategorizedView() {
                 <XStack gap="$2" alignItems="center">
                   <StyledButton
                     size="$small"
+                    theme="gray"
                     icon={<Icon name="pencil" />}
                     onPress={() => {
                       setBulkTitleValue("");

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   DatabaseContext,
   useTotalBlockCount,
@@ -42,6 +49,89 @@ import Animated, {
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 
 const GridGap = 3;
+
+// Memoized so toggling one item's selection only re-renders that cell rather
+// than every BlockSummary in the grid (the main cause of slow selection).
+const OrganizeGridCell = memo(function OrganizeGridCell({
+  block,
+  index,
+  selected,
+  cellSize,
+  onToggle,
+  onOpen,
+}: {
+  block: Block;
+  index: number;
+  selected: boolean;
+  cellSize: number;
+  onToggle: (id: string) => void;
+  onOpen: (index: number) => void;
+}) {
+  return (
+    <Pressable
+      onPress={() => onToggle(block.id)}
+      style={{ width: cellSize, height: cellSize, margin: GridGap }}
+    >
+      <YStack
+        width="100%"
+        height="100%"
+        borderRadius={8}
+        overflow="hidden"
+        backgroundColor="$gray3"
+        borderWidth={2}
+        borderColor={selected ? "$orange9" : "transparent"}
+        justifyContent="center"
+        alignItems="center"
+      >
+        <BlockSummary
+          block={block}
+          hideHoldMenu
+          hideMetadata
+          editable={false}
+          isVisible={false}
+          containerProps={{
+            width: "100%",
+            height: "100%",
+            gap: 0,
+            justifyContent: "center",
+          }}
+          style={{ width: "100%", height: "100%" }}
+          blockStyle={{ resizeMode: "cover" }}
+        />
+      </YStack>
+      {/* Selection badge */}
+      <YStack
+        position="absolute"
+        top={6}
+        right={6}
+        width={22}
+        height={22}
+        borderRadius={11}
+        borderWidth={1.5}
+        borderColor="white"
+        backgroundColor={selected ? "$orange9" : "rgba(0,0,0,0.25)"}
+        alignItems="center"
+        justifyContent="center"
+      >
+        {selected && <Icon name="checkmark" color="white" size={14} />}
+      </YStack>
+      {/* Open this item in the focused carousel (secondary) */}
+      <StyledButton
+        position="absolute"
+        bottom={6}
+        right={6}
+        size="$tiny"
+        circular
+        borderWidth={0}
+        backgroundColor="rgba(0,0,0,0.4)"
+        icon={
+          <Icon name="expand" type={IconType.FontAwesomeIcon} color="white" />
+        }
+        onPress={() => onOpen(index)}
+      />
+    </Pressable>
+  );
+});
 
 export function UncategorizedView() {
   const { addConnections, deleteBlock, updateBlock } =
@@ -397,85 +487,28 @@ export function UncategorizedView() {
                   paddingHorizontal: GridGap,
                   paddingBottom: 16,
                 }}
-                renderItem={({ item, index }) => {
-                  const selected = selectedBlockIds.has(item.id);
-                  return (
-                    <Pressable
-                      onPress={() => toggleBlockSelection(item.id)}
-                      style={{
-                        width: gridCellSize,
-                        height: gridCellSize,
-                        margin: GridGap,
-                      }}
-                    >
-                      <YStack
-                        width="100%"
-                        height="100%"
-                        borderRadius={8}
-                        overflow="hidden"
-                        backgroundColor="$gray3"
-                        borderWidth={2}
-                        borderColor={selected ? "$orange9" : "transparent"}
-                        justifyContent="center"
-                        alignItems="center"
-                      >
-                        <BlockSummary
-                          block={item}
-                          hideHoldMenu
-                          hideMetadata
-                          editable={false}
-                          isVisible={false}
-                          containerProps={{
-                            width: "100%",
-                            height: "100%",
-                            gap: 0,
-                            justifyContent: "center",
-                          }}
-                          style={{ width: "100%", height: "100%" }}
-                          blockStyle={{ resizeMode: "cover" }}
-                        />
-                      </YStack>
-                      {/* Selection badge */}
-                      <YStack
-                        position="absolute"
-                        top={6}
-                        right={6}
-                        width={22}
-                        height={22}
-                        borderRadius={11}
-                        borderWidth={1.5}
-                        borderColor="white"
-                        backgroundColor={
-                          selected ? "$orange9" : "rgba(0,0,0,0.25)"
-                        }
-                        alignItems="center"
-                        justifyContent="center"
-                      >
-                        {selected && (
-                          <Icon name="checkmark" color="white" size={14} />
-                        )}
-                      </YStack>
-                      {/* Open this item in the focused carousel (secondary) */}
-                      <StyledButton
-                        position="absolute"
-                        bottom={6}
-                        right={6}
-                        size="$tiny"
-                        circular
-                        borderWidth={0}
-                        backgroundColor="rgba(0,0,0,0.4)"
-                        icon={
-                          <Icon
-                            name="expand"
-                            type={IconType.FontAwesomeIcon}
-                            color="white"
-                          />
-                        }
-                        onPress={() => openInCarousel(index)}
-                      />
-                    </Pressable>
-                  );
+                removeClippedSubviews
+                initialNumToRender={15}
+                maxToRenderPerBatch={9}
+                windowSize={5}
+                getItemLayout={(_, index) => {
+                  const rowHeight = gridCellSize + GridGap * 2;
+                  return {
+                    length: rowHeight,
+                    offset: rowHeight * Math.floor(index / 3),
+                    index,
+                  };
                 }}
+                renderItem={({ item, index }) => (
+                  <OrganizeGridCell
+                    block={item}
+                    index={index}
+                    selected={selectedBlockIds.has(item.id)}
+                    cellSize={gridCellSize}
+                    onToggle={toggleBlockSelection}
+                    onOpen={openInCarousel}
+                  />
+                )}
               />
             </YStack>
           )}

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -460,9 +460,16 @@ export function UncategorizedView() {
                         position="absolute"
                         bottom={6}
                         right={6}
-                        size="$small"
+                        size="$tiny"
+                        circular
+                        borderWidth={0}
+                        backgroundColor="rgba(0,0,0,0.4)"
                         icon={
-                          <Icon name="expand" type={IconType.FontAwesomeIcon} />
+                          <Icon
+                            name="expand"
+                            type={IconType.FontAwesomeIcon}
+                            color="white"
+                          />
                         }
                         onPress={() => openInCarousel(index)}
                       />
@@ -484,7 +491,8 @@ export function UncategorizedView() {
               >
                 <XStack gap="$1.5" alignItems="center">
                   <StyledButton
-                    size="$small"
+                    size="$tiny"
+                    theme="red"
                     icon={<Icon name="close" />}
                     onPress={() => setSelectedBlockIds(new Set())}
                   />
@@ -552,7 +560,7 @@ export function UncategorizedView() {
             padding="$4"
             gap="$3"
           >
-            <StyledText bold fontSize="$5">
+            <StyledText bold size="$5">
               Title {selectedBlockIds.size} item
               {selectedBlockIds.size > 1 ? "s" : ""}
             </StyledText>

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -612,6 +612,8 @@ export function UncategorizedView() {
             <XStack gap="$2" justifyContent="flex-end">
               <StyledButton
                 chromeless
+                theme="gray"
+                pressStyle={{ backgroundColor: "$gray5" }}
                 onPress={() => setBulkTitleVisible(false)}
               >
                 Cancel

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -172,27 +172,6 @@ export function UncategorizedView() {
 
     return (
       <>
-        <StyledButton
-          position="absolute"
-          top={6}
-          right={6}
-          zIndex={5}
-          size="$small"
-          icon={<Icon name="trash" />}
-          theme="red"
-          onPress={() => {
-            handleDeleteBlock(item.id);
-          }}
-        />
-        <StyledText
-          marginBottom="auto"
-          textAlign="center"
-          width="100%"
-          marginTop="$1.5"
-        >
-          {index + 1} / {events.length} unconnected,{" "}
-          {totalBlocks === null ? "..." : totalBlocks} total
-        </StyledText>
         <YStack
           paddingVertical="$2"
           // NOTE: minHeight is ideal here for aesthetic but we need to handle
@@ -299,20 +278,44 @@ export function UncategorizedView() {
     >
       <Animated.View style={{ ...translateStyle }}>
         <Stack minHeight="100%">
-          {/* Focused (swipe) / Grid view toggle — matches the Review view's
-              single toggle button that swaps icons. */}
-          <StyledButton
-            position="absolute"
-            top={6}
-            left={6}
-            zIndex={10}
-            size="$small"
-            backgroundColor="$gray6"
-            icon={<Icon name={viewMode === "swipe" ? "grid" : "image"} />}
-            onPress={() =>
-              setViewMode((m) => (m === "swipe" ? "grid" : "swipe"))
-            }
-          />
+          {/* Header row: view toggle · count · delete (single flex row so the
+              toggle and trash always line up). */}
+          <XStack
+            alignItems="center"
+            paddingHorizontal={6}
+            paddingTop={6}
+            gap="$2"
+          >
+            <StyledButton
+              size="$small"
+              backgroundColor="$gray6"
+              icon={<Icon name={viewMode === "swipe" ? "grid" : "image"} />}
+              onPress={() =>
+                setViewMode((m) => (m === "swipe" ? "grid" : "swipe"))
+              }
+            />
+            <StyledText flex={1} textAlign="center">
+              {viewMode === "swipe" ? `${currentIdx + 1} / ` : ""}
+              {events.length} unconnected,{" "}
+              {totalBlocks === null ? "..." : totalBlocks} total
+            </StyledText>
+            {viewMode === "swipe" ? (
+              <StyledButton
+                size="$small"
+                icon={<Icon name="trash" />}
+                theme="red"
+                onPress={() => {
+                  const current = events[currentIdx];
+                  if (current) {
+                    handleDeleteBlock(current.id);
+                  }
+                }}
+              />
+            ) : (
+              // Spacer to keep the count centered when the trash is hidden.
+              <Stack width={40} />
+            )}
+          </XStack>
 
           {viewMode === "swipe" ? (
             <XStack
@@ -351,10 +354,6 @@ export function UncategorizedView() {
             </XStack>
           ) : (
             <YStack flex={1} flexGrow={1}>
-              <StyledText textAlign="center" marginTop="$1.5" marginBottom="$1">
-                {events.length} unconnected,{" "}
-                {totalBlocks === null ? "..." : totalBlocks} total
-              </StyledText>
               <FlatList
                 data={events}
                 keyExtractor={(item) => item.id}

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -5,7 +5,7 @@ import {
   useUncategorizedBlocks,
 } from "../utils/db";
 import { Block } from "../utils/dataTypes";
-import { Icon, IconType, StyledButton, StyledText } from "../components/Themed";
+import { Icon, StyledButton, StyledText } from "../components/Themed";
 import {
   Dimensions,
   FlatList,
@@ -318,9 +318,7 @@ export function UncategorizedView() {
               backgroundColor={
                 viewMode === "swipe" ? "$background" : "transparent"
               }
-              icon={
-                <Icon name="square" type={IconType.FontAwesomeIcon} size={24} />
-              }
+              icon={<Icon name="albums" size={22} />}
               onPress={() => setViewMode("swipe")}
             />
             <StyledButton
@@ -331,9 +329,7 @@ export function UncategorizedView() {
               backgroundColor={
                 viewMode === "grid" ? "$background" : "transparent"
               }
-              icon={
-                <Icon name="th" type={IconType.FontAwesomeIcon} size={24} />
-              }
+              icon={<Icon name="grid" size={22} />}
               onPress={() => setViewMode("grid")}
             />
           </XStack>

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -272,7 +272,7 @@ export function UncategorizedView() {
     );
     setBulkTitleValue("");
     setBulkTitleVisible(false);
-    setSelectedBlockIds(new Set());
+    // Keep the selection so the user can connect the titled items next.
   }, [bulkTitleValue, selectedBlockIds, updateBlock]);
 
   // Open a block from the grid in the focused carousel ("drill in").

--- a/views/UncategorizedView.tsx
+++ b/views/UncategorizedView.tsx
@@ -302,28 +302,30 @@ export function UncategorizedView() {
           {/* Swipe / Grid view toggle */}
           <XStack
             position="absolute"
-            top={4}
-            right={8}
+            top={6}
+            left={8}
             zIndex={10}
-            backgroundColor="$gray3"
-            borderRadius={20}
-            padding={2}
-            gap={2}
+            backgroundColor="$gray4"
+            borderRadius={22}
+            padding={3}
+            gap={3}
           >
             <StyledButton
-              size="$2"
               circular
-              chromeless
+              size="$3"
+              chromeless={viewMode !== "swipe"}
+              theme={viewMode === "swipe" ? "orange" : undefined}
               backgroundColor={viewMode === "swipe" ? "$background" : "transparent"}
-              icon={<Icon name="albums" size={18} />}
+              icon={<Icon name="albums" size={22} />}
               onPress={() => setViewMode("swipe")}
             />
             <StyledButton
-              size="$2"
               circular
-              chromeless
+              size="$3"
+              chromeless={viewMode !== "grid"}
+              theme={viewMode === "grid" ? "orange" : undefined}
               backgroundColor={viewMode === "grid" ? "$background" : "transparent"}
-              icon={<Icon name="grid" size={18} />}
+              icon={<Icon name="grid" size={22} />}
               onPress={() => setViewMode("grid")}
             />
           </XStack>


### PR DESCRIPTION
## What & why

Two related improvements for adding and organizing media:

1. **Custom in-app photo picker** that shows which photos are already in Gather, so you don't re-add duplicates — while keeping multi-select as easy as the native picker.
2. **A grid view in the organize tab** so you can see everything at once, jump to any item, and multi-select to bulk-connect — instead of only swiping one-at-a-time.

## Custom photo picker (`components/CustomPhotoPicker.tsx`)

Replaces the native OS image picker in the composer with our own grid built on `expo-media-library` (already a dependency, previously unused).

- Pages through the camera roll and **cross-references each asset against the DB** (`getExistingAssetIds` on `local_asset_id`), badging + dimming already-added photos. They're **not selectable**, so you can't accidentally re-add them.
- **Filter toggle: All / Not added / Added.**
- Ordered multi-select with numbered badges (mirrors the old `orderedSelection`).
- Carries over capture time + GPS→location metadata from each asset, matching the existing EXIF flow.
- Presented as a **pageSheet** (swipe-to-dismiss) with a full-width **Add N photos** button pinned to the bottom — no top bar to clip under the notch/Dynamic Island.
- Robust permission handling: gated behind an explicit permission check and wrapped so it can't surface an unhandled `MEDIA_LIBRARY permission is required` rejection.

## Organize grid view (`views/UncategorizedView.tsx`)

- Adds a **Swipe ⇄ Grid toggle** (single icon-swap button matching the Review view). Carousel stays the default.
- Grid is a 3-column list of the uncategorized blocks. Tap a thumbnail's expand icon to **jump straight to it in the swipe carousel**; tap a thumbnail to **multi-select and bulk-connect** all selected blocks to collections at once.
- The view toggle, item count, and delete button now live in a single header row so they stay aligned.

## Other

- Registered the `expo-media-library` config plugin in `app.json` for photo permissions + media-location access.

## Notes / testing

- `tsc` passes for all changed files (the only errors are two pre-existing ones in `TextForageView` unrelated to this change).
- ⚠️ **Requires a native rebuild** — the new `expo-media-library` config plugin adds permission entries, so this won't work via a JS-only reload.

https://claude.ai/code/session_01QjuAD4Sbkc3FaYMKnoPqSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjuAD4Sbkc3FaYMKnoPqSq)_