### PR TITLE
Add block search by title, description, and text content

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,7 +40,7 @@ export default function TabLayout() {
           tabBarLabel: "",
           headerShown: true,
           tabBarIcon: ({ color }) => <TabBarIcon name="create" color={color} />,
-          headerRight: () => headerIcons,
+          headerRight: () => <HeaderIcon href="/search" icon="search" />,
         }}
       />
       <Tabs.Screen

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -98,7 +98,7 @@ export default function RootLayout() {
   useEffect(() => {
     if (Platform.OS === "android") {
       NavigationBar.setBackgroundColorAsync(
-        colorScheme === "light" ? "white" : "black"
+        colorScheme === "light" ? "white" : "black",
       );
     }
   }, [colorScheme]);
@@ -254,6 +254,13 @@ function RootLayoutNav() {
         name="collection/[id]/index"
         options={{
           presentation: "card",
+        }}
+      />
+      <Stack.Screen
+        name="search"
+        options={{
+          presentation: "card",
+          title: "Search",
         }}
       />
       <Stack.Screen

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -1,0 +1,5 @@
+import { SearchView } from "../views/SearchView";
+
+export default function SearchScreen() {
+  return <SearchView />;
+}

--- a/utils/db.tsx
+++ b/utils/db.tsx
@@ -1182,9 +1182,20 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
     whereClause,
     sortType = SortType.Created,
     seed,
-  }: GetBlocksOptions = {}) =>
-    `${SelectBlockSql}
-    WHERE deletion_timestamp IS NULL${whereClause ? ` AND ${whereClause}` : ""}
+    search,
+  }: GetBlocksOptions = {}) => {
+    const searchClause = search
+      ? (() => {
+          const escaped = getEscapedSearchString(search);
+          // Match title/description on any block, plus the content body for
+          // text blocks (media content is a file path, so don't match it).
+          return ` AND (blocks.title LIKE ${escaped} OR blocks.description LIKE ${escaped} OR (blocks.type = '${BlockType.Text}' AND blocks.content LIKE ${escaped}))`;
+        })()
+      : "";
+    return `${SelectBlockSql}
+    WHERE deletion_timestamp IS NULL${
+      whereClause ? ` AND ${whereClause}` : ""
+    }${searchClause}
     ${SelectBlocksSortTypeToClause(
       sortType,
       "block_connections.remote_connected_at",
@@ -1196,17 +1207,19 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
         ? ""
         : `LIMIT ${BlockSelectLimit} OFFSET ${page * BlockSelectLimit}`
     };`;
+  };
 
   async function getBlocks({
     page = 0,
     whereClause,
     sortType = SortType.Created,
     seed,
+    search,
   }: GetBlocksOptions = {}): Promise<Block[]> {
     const [result] = await db.execAsync(
       [
         {
-          sql: `${SelectBlocksSql({ page, sortType, seed, whereClause })};`,
+          sql: `${SelectBlocksSql({ page, sortType, seed, whereClause, search })};`,
           args: [],
         },
       ],
@@ -2019,7 +2032,7 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
                   null;
                 if (blockMappedToCamelCase.collectionRemoteSourceInfos) {
                   const parsed = JSON.parse(
-                    blockMappedToCamelCase.collectionRemoteSourceInfos
+                    blockMappedToCamelCase.collectionRemoteSourceInfos,
                   );
                   // json_group_array may return items as JSON objects (not
                   // double-quoted strings) depending on SQLite version, so
@@ -2027,7 +2040,7 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
                   collectionRemoteSourceInfos = parsed.map((info: any) =>
                     typeof info === "string"
                       ? (JSON.parse(info) as RemoteSourceInfo)
-                      : (info as RemoteSourceInfo)
+                      : (info as RemoteSourceInfo),
                   );
                 }
 
@@ -2040,14 +2053,14 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
                 } as BlockWithCollectionInfo;
               } catch (err) {
                 logError(
-                  `[Arena Sync] Failed to parse pending block row id=${block.id}: ${err}`
+                  `[Arena Sync] Failed to parse pending block row id=${block.id}: ${err}`,
                 );
                 return null;
               }
             })
             .filter(
               (b): b is BlockWithCollectionInfo =>
-                b !== null && !queuedBlocksToSync.current.has(b.id)
+                b !== null && !queuedBlocksToSync.current.has(b.id),
             );
 
           connectionsToSync.forEach((c) =>
@@ -2202,11 +2215,8 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
               block.id,
               collectionInfo.collectionId,
               conn?.user?.slug
-                ? getCreatedByForRemote(
-                    RemoteSourceType.Arena,
-                    conn.user.slug
-                  )
-                : currentUser?.id ?? "unknown",
+                ? getCreatedByForRemote(RemoteSourceType.Arena, conn.user.slug)
+                : (currentUser?.id ?? "unknown"),
               conn?.connected_at ?? new Date().toISOString(),
             ],
           };
@@ -3116,6 +3126,55 @@ export function useCollections({
     isLoading,
     debouncedFetchMoreCollections,
     isFetchingNextPage,
+  };
+}
+
+// Full-text-ish search across blocks (title, description, and text content).
+export function useBlockSearch(searchValue: string) {
+  const { getBlocks } = useContext(DatabaseContext);
+  const debouncedSearch = useDebounceValue(searchValue, 300);
+  const trimmedSearch = (debouncedSearch || "").trim();
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["blocks", { search: trimmedSearch }],
+    queryFn: async ({ pageParam: page, queryKey }) => {
+      const [_, { search }] = queryKey as [string, { search: string }];
+      const blocks = await getBlocks({ page, search });
+      return {
+        blocks,
+        nextId: blocks.length < BlockSelectLimit ? null : page + 1,
+        previousId: page === 0 ? null : page - 1,
+      };
+    },
+    initialPageParam: 0,
+    getPreviousPageParam: (firstPage) => firstPage?.previousId ?? undefined,
+    getNextPageParam: (lastPage) => lastPage?.nextId ?? undefined,
+    enabled: trimmedSearch.length > 0,
+  });
+
+  const blocks = useMemo(() => data?.pages.flatMap((p) => p.blocks), [data]);
+
+  const fetchMore = useCallback(() => {
+    if (isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+    fetchNextPage();
+  }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
+
+  return {
+    blocks: trimmedSearch.length > 0 ? blocks : undefined,
+    isLoading: isLoading && trimmedSearch.length > 0,
+    isFetching,
+    isFetchingNextPage,
+    fetchMore,
+    hasSearch: trimmedSearch.length > 0,
   };
 }
 

--- a/views/SearchView.tsx
+++ b/views/SearchView.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { FlatList, Keyboard } from "react-native";
+import { Spinner, YStack } from "tamagui";
+import { BlockSummary } from "../components/BlockSummary";
+import { SearchBarInput, StyledText } from "../components/Themed";
+import { useBlockSearch } from "../utils/db";
+
+export function SearchView() {
+  const [searchValue, setSearchValue] = useState("");
+  const { blocks, isLoading, fetchMore, isFetchingNextPage, hasSearch } =
+    useBlockSearch(searchValue);
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <YStack padding="$3" paddingBottom="$2">
+        <SearchBarInput
+          searchValue={searchValue}
+          setSearchValue={setSearchValue}
+          autoFocus
+          placeholder="Search your blocks..."
+        />
+      </YStack>
+
+      {!hasSearch ? (
+        <YStack
+          flex={1}
+          alignItems="center"
+          paddingTop="$8"
+          paddingHorizontal="$4"
+        >
+          <StyledText metadata textAlign="center">
+            Search across your blocks by title, description, or text.
+          </StyledText>
+        </YStack>
+      ) : isLoading ? (
+        <YStack flex={1} alignItems="center" paddingTop="$8">
+          <Spinner color="$orange9" size="large" />
+        </YStack>
+      ) : blocks && blocks.length === 0 ? (
+        <YStack flex={1} alignItems="center" paddingTop="$8">
+          <StyledText metadata>No results found.</StyledText>
+        </YStack>
+      ) : (
+        <FlatList
+          data={blocks}
+          keyExtractor={(item) => item.id}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          contentContainerStyle={{
+            paddingHorizontal: 12,
+            paddingBottom: 40,
+            gap: 16,
+          }}
+          onEndReached={fetchMore}
+          onEndReachedThreshold={1}
+          renderItem={({ item }) => (
+            <BlockSummary
+              block={item}
+              shouldLink
+              hideHoldMenu
+              containerProps={{ width: "100%" }}
+              blockStyle={{ resizeMode: "cover", maxHeight: 240 }}
+            />
+          )}
+          ListFooterComponent={
+            isFetchingNextPage ? (
+              <YStack paddingVertical="$3" alignItems="center">
+                <Spinner color="$orange9" />
+              </YStack>
+            ) : null
+          }
+        />
+      )}
+    </YStack>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a dedicated block search screen so you can find your blocks across **title**, **description**, and (for text blocks) **text content**.

- New `Search` screen (`app/search.tsx` + `views/SearchView.tsx`) with an autofocused search bar, loading/empty states, and an infinite-scrolling result list of `BlockSummary` cards.
- The home tab's header-right icon is now a search icon linking to `/search`.
- `useBlockSearch` hook in `utils/db.tsx` — debounced (300ms), paginated via `useInfiniteQuery`, only runs when there's a non-empty query.
- `getBlocks` / `SelectBlocksSql` gain a `search` option. The SQL matches `title`/`description` on any block, plus `content` only for text blocks (media content is a file path, so it's excluded). Search strings are escaped via `getEscapedSearchString`.

## Notes

Also includes a few incidental Prettier formatting fixups in `utils/db.tsx` and `app/_layout.tsx` that were touched alongside the changes.

https://claude.ai/code/session_01QjuAD4Sbkc3FaYMKnoPqSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjuAD4Sbkc3FaYMKnoPqSq)_